### PR TITLE
Adding keyCertSign parameter to make possible to verify

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/req.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/req.j2
@@ -12,7 +12,7 @@ O = Quay
 OU = Division
 CN = {{ quay_hostname.split(":")[0] if (":" in quay_hostname) else quay_hostname }}
 [v3_req]
-keyUsage = keyEncipherment, dataEncipherment
+keyUsage = keyEncipherment, dataEncipherment, keyCertSign
 extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]


### PR DESCRIPTION
certificate against itself. It fixes issue #8:
Self-signed certificate has wrong keyUsage - it misses keyCertSign