### PR TITLE
MOD: manage the quay-pod via systemd

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/defaults/main.yml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/defaults/main.yml
@@ -2,6 +2,7 @@
 redis_image: "registry.redhat.io/rhel8/redis-6:1-25"
 postgres_image: "registry.redhat.io/rhel8/postgresql-10:1-161"
 quay_image: "registry.redhat.io/quay/quay-rhel8:v3.6.1"
+pause_image: "registry.access.redhat.com/ubi8/pause:latest"
 quay_hostname: "quay:8443"
 quay_root: "/etc/quay-install"
 auto_approve: "false"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/create-podman-pod.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/create-podman-pod.yaml
@@ -1,6 +1,0 @@
-- name: Starting Pod with ports 80 and 443 exposed
-  containers.podman.podman_pod:
-    name: quay-pod
-    state: started
-    ports:
-      - '{{ quay_hostname.split(":")[1] if (":" in quay_hostname) else "8443" }}:8443'

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-pod-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-pod-service.yaml
@@ -1,0 +1,23 @@
+- name: Copy Quay Pod systemd service file
+  template:
+    src: ../templates/pod.service.j2
+    dest: /etc/systemd/system/quay-pod.service
+
+- name: Check if pod pause image is loaded
+  command: podman inspect --type=image {{ pause_image }}
+  register: r
+  ignore_errors: yes
+
+- name: Pull Infra image
+  containers.podman.podman_image:
+    name: "{{ pause_image }}"
+  when: r.rc != 0
+  retries: 5
+  delay: 5
+
+- name: Start Quay Pod service
+  systemd:
+    name: quay-pod.service
+    enabled: yes
+    daemon_reload: yes
+    state: started

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/main.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/main.yaml
@@ -4,8 +4,8 @@
 - name: Set SELinux Rules
   include_tasks: set-selinux-rules.yaml
 
-- name: Create Podman Pod
-  include_tasks: create-podman-pod.yaml
+- name: Install Quay Pod Service
+  include_tasks: install-pod-service.yaml
 
 - name: Autodetect Image Archive
   include_tasks: autodetect-image-archive.yaml

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/pod.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/pod.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description=Infra Container for Quay
+Wants=network.target
+After=network-online.target
+Before=quay-postgres.service quay-redis.service
+
+[Service]
+Type=simple
+RemainAfterExit=yes
+TimeoutStartSec=5m
+ExecStartPre=-/bin/rm -f %t/%n-pid %t/%n-pod-id
+ExecStart=/usr/bin/podman pod create \
+    --name quay-pod \
+    --infra-image {{ pause_image }} \
+    --publish {{ quay_hostname.split(":")[1] if (":" in quay_hostname) else "8443" }}:8443 \
+    --pod-id-file %t/%n-pod-id \
+    --replace
+ExecStop=-/usr/bin/podman pod stop --ignore --pod-id-file %t/%n-pod-id -t 10
+ExecStopPost=-/usr/bin/podman pod rm --ignore -f --pod-id-file %t/%n-pod-id
+PIDFile=%t/%n-pid
+KillMode=none
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target default.target
+

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/postgres.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/postgres.service.j2
@@ -1,7 +1,8 @@
 [Unit]
 Description=PostgreSQL Podman Container for Quay
 Wants=network.target
-After=network-online.target
+After=network-online.target quay-pod.service
+Requires=quay-pod.service
 
 [Service]
 Type=simple

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
@@ -1,8 +1,8 @@
 [Unit]
 Description=Quay Container
 Wants=network.target
-After=network-online.target
-Requires=quay-postgres.service quay-redis.service
+After=network-online.target quay-pod.service quay-postgres.service quay-redis.service
+Requires=quay-pod.service quay-postgres.service quay-redis.service
 
 [Service]
 Type=simple

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/redis.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/redis.service.j2
@@ -1,7 +1,8 @@
 [Unit]
 Description=Redis Podman Container for Quay
 Wants=network.target
-After=network-online.target
+After=network-online.target quay-pod.service
+Requires=quay-pod.service
 
 [Service]
 Type=simple

--- a/ansible-runner/context/app/project/uninstall_mirror_appliance.yml
+++ b/ansible-runner/context/app/project/uninstall_mirror_appliance.yml
@@ -39,6 +39,14 @@
         state: stopped
         force: yes
 
+    - name: Stop Quay Pod service
+      systemd:
+        name: quay-pod.service
+        enabled: no
+        daemon_reload: yes
+        state: stopped
+        force: yes
+
     - name: Delete pod
       containers.podman.podman_pod:
         name: quay-pod

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -103,7 +103,7 @@ func install() {
 	log.Printf("Install has begun")
 
 	log.Debug("Ansible Execution Environment Image: " + eeImage)
-	log.Debug("Redis Image: " + pauseImage)
+	log.Debug("Pause Image: " + pauseImage)
 	log.Debug("Quay Image: " + quayImage)
 	log.Debug("Redis Image: " + redisImage)
 	log.Debug("Postgres Image: " + postgresImage)


### PR DESCRIPTION
This PR should fix #48
- the pod `quay-pod` is created an managed by a systemd unit
- the other quay systemd uints require the `quay-pod`
