### PR TITLE
logging: Set logging level to INFO from DEBUG (PROJQUAY-3504)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
@@ -12,7 +12,6 @@ ExecStart=/usr/bin/podman run \
     --name quay-app \
     -v {{ quay_root }}/quay-config:/quay-registry/conf/stack:Z \
     -v {{ quay_root }}/quay-storage:/datastorage:Z \
-    -e DEBUGLOG=true \
     --pod=quay-pod \
     --conmon-pidfile %t/%n-pid \
     --cidfile %t/%n-cid \


### PR DESCRIPTION
- Lower logging level from DEBUG to INFO to reduce size of output
- Log rotation would have to be handled by the user in their journald configuration