### PR TITLE
allow controlling colored output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following flags are also available:
 --targetHostname    -H  The hostname of the target you wish to install Quay to. This defaults to $HOST.
 --targetUsername    -u  The user on the target host which will be used for SSH. This defaults to $USER
 --verbose           -v  Show debug logs and ansible playbook outputs
+--no-color          -c  Force disabling colored output
 ```
 
 **Note**: You may need to modify the value for `--quayHostname` in case the public DNS name of your system is different from its local hostname.

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -266,6 +266,7 @@ func install() {
 		`-e RUNNER_ONLY_FAILED_EVENTS=False `+
 		`-e ANSIBLE_HOST_KEY_CHECKING=False `+
 		`-e ANSIBLE_CONFIG=/runner/project/ansible.cfg `+
+		fmt.Sprintf("-e ANSIBLE_NOCOLOR=%t ", noColor)+
 		`--quiet `+
 		`--name ansible_runner_instance `+
 		fmt.Sprintf("%s ", eeImage)+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,11 +17,15 @@ var log = &logrus.Logger{
 // verbose is the optional command that will display INFO logs
 var verbose bool
 
+// noColor is the optional flag for controlling ANSI sequence output
+var noColor bool
+
 // version is an optional command that will display the current release version
 var releaseVersion string
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Display verbose logs")
+	rootCmd.PersistentFlags().BoolVarP(&noColor, "no-color", "c", false, "Control colored output")
 }
 
 var (
@@ -41,7 +45,7 @@ var (
 // Execute executes the root command.
 func Execute() error {
 	log.SetFormatter(&logrus.TextFormatter{
-		ForceColors:     true,
+		DisableColors:   noColor,
 		TimestampFormat: "2006-01-02 15:04:05",
 		FullTimestamp:   true,
 	})

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -72,6 +72,7 @@ func uninstall() {
 		`-e RUNNER_ONLY_FAILED_EVENTS=False `+
 		`-e ANSIBLE_HOST_KEY_CHECKING=False `+
 		`-e ANSIBLE_CONFIG=/runner/project/ansible.cfg `+
+		fmt.Sprintf("-e ANSIBLE_NOCOLOR=%t ", noColor)+
 		`--quiet `+
 		`--name ansible_runner_instance `+
 		fmt.Sprintf("%s ", eeImage)+

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -184,6 +184,7 @@ func upgrade() {
 		`-e RUNNER_ONLY_FAILED_EVENTS=False `+
 		`-e ANSIBLE_HOST_KEY_CHECKING=False `+
 		`-e ANSIBLE_CONFIG=/runner/project/ansible.cfg `+
+		fmt.Sprintf("-e ANSIBLE_NOCOLOR=%t ", noColor)+
 		`--quiet `+
 		`--name ansible_runner_instance `+
 		fmt.Sprintf("%s ", eeImage)+


### PR DESCRIPTION
Wrapping the execution of `mirror-registry install` in Ansible results
in printing ANSI color sequences without rendering them. Allow for
disabling color with `--no-color` and propogate that to the container
running Ansible.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

closes #80 

So this doesn't disable colors completely, logrus is still doing some funky formatting when a `tty` is available (even with `--no-color` set), but fixes the problem of escape sequences being printed when wrapping in Ansible. When disabling color through `logrus`, it uses what they call a `colorless` format which is meant to be machine readable, so the log output differs based on whether we set `DisableColors` to `true/false`, this probably isn't the best..

 Also, the name of the flag may not be ideal, happy for any other suggestions :smile_cat: 

https://github.com/sirupsen/logrus/pull/195

![2022-08-16_11-43](https://user-images.githubusercontent.com/29494941/184936668-55d94e26-3987-46b5-9676-cb45f6d21214.png)
