### PR TITLE
Resolve issue with missing FQDN (PROJQUAY-4139)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG REDIS_IMAGE=${REDIS_IMAGE}
 ARG PAUSE_IMAGE=${PAUSE_IMAGE}
 
 # Create Go CLI
-FROM registry.redhat.io/ubi8:latest AS cli
+FROM registry.access.redhat.com/ubi8:latest AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}
@@ -75,7 +75,7 @@ FROM $POSTGRES_IMAGE as postgres
 FROM $PAUSE_IMAGE as pause
 
 # Create mirror registry archive
-FROM registry.redhat.io/ubi8:latest AS build
+FROM registry.access.redhat.com/ubi8:latest AS build
 
 # Import and archive image dependencies
 COPY --from=pause / /pause
@@ -102,5 +102,5 @@ RUN tar -cvf image-archive.tar quay.tar redis.tar postgres.tar pause.tar
 RUN tar -czvf mirror-registry.tar.gz image-archive.tar execution-environment.tar mirror-registry
 
 # Extract bundle to final release image
-FROM registry.redhat.io/ubi8:latest AS release
+FROM registry.access.redhat.com/ubi8:latest AS release
 COPY --from=build mirror-registry.tar.gz mirror-registry.tar.gz

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -10,8 +10,6 @@ import (
 	"os/exec"
 	"path"
 	"strings"
-
-	"github.com/Showmax/go-fqdn"
 )
 
 func loadExecutionEnvironment() error {
@@ -296,9 +294,11 @@ func getApproval(question string) bool {
 }
 
 func getFQDN() string {
-	fqdn, err := fqdn.FqdnHostname()
+	fqdn, err := exec.Command("hostname", "-f").Output()
 	if err != nil {
-		log.Fatal(err)
+		errorMessage := "Failed to automatically acquire host FQDN, please set manually with --targetHostname. "
+		log.Fatal(errorMessage, err)
 	}
-	return fqdn
+
+	return strings.TrimSuffix(string(fqdn), "\n")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/quay/mirror-registry
 go 1.16
 
 require (
-	github.com/Showmax/go-fqdn v1.0.0
 	github.com/lib/pq v1.10.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
-github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
* Replaces fqdn library with `hostname -f`
* Should resolve https://github.com/quay/mirror-registry/issues/60