### PR TITLE
Build as normal user and not as root (PROJQUAY-4630)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ CLIENT ?= podman
 all:
 
 build-golang-executable:
-	sudo $(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.16 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.16 go build -v \
 	-ldflags "-X github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE} -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.postgresImage=${POSTGRES_IMAGE}'" \
 	-o mirror-registry;
 
 build-online-zip: 
-	sudo $(CLIENT) build \
+	$(CLIENT) build \
 		-t mirror-registry-online:${RELEASE_VERSION} \
 		--build-arg RELEASE_VERSION=${RELEASE_VERSION} \
 		--build-arg QUAY_IMAGE=${QUAY_IMAGE} \
@@ -21,11 +21,11 @@ build-online-zip:
 		--build-arg REDIS_IMAGE=${REDIS_IMAGE} \
 		--build-arg PAUSE_IMAGE=${PAUSE_IMAGE} \
 		--file Dockerfile.online . 
-	sudo $(CLIENT) run --name mirror-registry-online-${RELEASE_VERSION} mirror-registry-online:${RELEASE_VERSION}
-	sudo $(CLIENT) cp mirror-registry-online-${RELEASE_VERSION}:/mirror-registry.tar.gz .
+	$(CLIENT) run --name mirror-registry-online-${RELEASE_VERSION} mirror-registry-online:${RELEASE_VERSION}
+	$(CLIENT) cp mirror-registry-online-${RELEASE_VERSION}:/mirror-registry.tar.gz .
 
 build-offline-zip: 
-	sudo $(CLIENT) build \
+	$(CLIENT) build \
 		-t mirror-registry-offline:${RELEASE_VERSION} \
 		--build-arg RELEASE_VERSION=${RELEASE_VERSION} \
 		--build-arg QUAY_IMAGE=${QUAY_IMAGE} \
@@ -36,8 +36,8 @@ build-offline-zip:
 		--build-arg REDIS_IMAGE=${REDIS_IMAGE} \
 		--build-arg PAUSE_IMAGE=${PAUSE_IMAGE} \
 		--file Dockerfile .
-	sudo $(CLIENT) run --name mirror-registry-offline-${RELEASE_VERSION} mirror-registry-offline:${RELEASE_VERSION}
-	sudo $(CLIENT) cp mirror-registry-offline-${RELEASE_VERSION}:/mirror-registry.tar.gz .
+	$(CLIENT) run --name mirror-registry-offline-${RELEASE_VERSION} mirror-registry-offline:${RELEASE_VERSION}
+	$(CLIENT) cp mirror-registry-offline-${RELEASE_VERSION}:/mirror-registry.tar.gz .
 
 clean:
 	rm -rf mirror-registry* image-archive.tar


### PR DESCRIPTION
All commands in the Makefile start with "sudo". Building the code base should not require root access. And mistakes in the code or commands could seriously impact a system, i.e a misplaced rm -rf.