### PR TITLE
Bump Quay v3.7.10 (PROJQUAY-4677)

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 EE_IMAGE=quay.io/quay/mirror-registry-ee:latest
 EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-202
 EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-builder-rhel8:1.1.0-77
-POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-10:1-195.1665590956
-QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.7.9
-REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-78.1665590931
-RELEASE_VERSION=v1.2.8
+POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-10:1-202.1666660384
+QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.7.10
+REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-88.1666660352
+RELEASE_VERSION=v1.2.9
 PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:8.6-21


### PR DESCRIPTION
* Updates Quay to 3.7.10
* Updates Redis and Postgres to latest z-stream
* Bump to Mirror Registry 1.2.9