### PR TITLE
Remove sudo requirement (PROJQUAY-4630)

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 EE_IMAGE=quay.io/quay/mirror-registry-ee:latest
-EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-202
-EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-builder-rhel8:1.1.0-77
-POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-10:1-202.1666660384
-QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.7.10
-REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-88.1666660352
-RELEASE_VERSION=v1.2.9
-PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:8.6-21
+EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-249
+EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-builder-rhel8:1.1.0-103
+POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-10:1-203.1669834630
+QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.8.0
+REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-92.1669834635
+RELEASE_VERSION=v1.3.0
+PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:8.7-6

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -54,11 +54,15 @@ jobs:
               dep ensure
           fi
 
+      - name: Log into docker for registry.redhat.io
+        uses: docker/login-action@v2
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
       - name: Install ansible builder
         run: sudo pip install ansible-builder
-
-      - name: Log into docker for registry.redhat.io
-        run: "sudo docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} registry.redhat.io"
 
       - name: Build tarfile
         run: CLIENT=docker make build-${{ matrix.installer-type }}-zip
@@ -103,12 +107,14 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.TF_VAR_SSH_PRIVATE_KEY }}
 
-      - name: Write SSH Key
-        run: 'echo "$SSH_KEY" > /home/runner/.ssh/id_rsa'
+      - name: Write SSH Key id_rsa
+        run: |
+          echo "$SSH_KEY" > /home/runner/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
         env:
           SSH_KEY: ${{ secrets.TF_VAR_SSH_PRIVATE_KEY }}
 
-      - name: Write SSH Key
+      - name: Write SSH Key staging.key
         run: |
           mkdir -p ~/.ssh/
           echo "$SSH_KEY" > ~/.ssh/staging.key
@@ -140,12 +146,15 @@ jobs:
 
       - name: Extract tarfile
         run: tar -xf mirror-registry.tar.gz
+      
+      - name: Add quay to /etc/hosts
+        run: ssh jonathan@quay 'sudo echo "127.0.0.1 quay" >> /etc/hosts'
 
       - name: Install podman
         run: ssh jonathan@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
       - name: Log into podman for registry.redhat.io
-        run: ssh jonathan@quay "sudo podman login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} registry.redhat.io"
+        run: ssh jonathan@quay "podman login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} registry.redhat.io"
         if: matrix.installer-type == 'online'
 
       - name: Install Registry
@@ -202,12 +211,14 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.TF_VAR_SSH_PRIVATE_KEY }}
 
-      - name: Write SSH Key
-        run: 'echo "$SSH_KEY" > /home/runner/.ssh/id_rsa'
+      - name: Write SSH Key id_rsa
+        run: |
+          echo "$SSH_KEY" > /home/runner/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
         env:
           SSH_KEY: ${{ secrets.TF_VAR_SSH_PRIVATE_KEY }}
 
-      - name: Write SSH Key
+      - name: Write SSH Key staging.key
         run: |
           mkdir -p ~/.ssh/
           echo "$SSH_KEY" > ~/.ssh/staging.key
@@ -240,11 +251,14 @@ jobs:
       - name: SCP tarball to VM
         run: scp mirror-registry.tar.gz jonathan@quay:~/mirror-registry.tar.gz
 
+      - name: Add quay to /etc/hosts
+        run: ssh jonathan@quay 'sudo echo "127.0.0.1 quay" >> /etc/hosts'
+
       - name: Install podman
         run: ssh jonathan@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
       - name: Log into podman for registry.redhat.io
-        run: ssh jonathan@quay "sudo podman login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} registry.redhat.io"
+        run: ssh jonathan@quay "podman login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} registry.redhat.io"
         if: matrix.installer-type == 'online'
 
       - name: Disable outbound network traffic

--- a/.github/workflows/local-offline-installer/main.tf
+++ b/.github/workflows/local-offline-installer/main.tf
@@ -30,7 +30,7 @@ resource "google_compute_instance" "vm_instance_local_offline_install" {
 
   boot_disk {
     initialize_params {
-      image = "rhel-8"
+      image = "rhel-9"
       size  = 100
     }
   }

--- a/.github/workflows/local-online-installer/main.tf
+++ b/.github/workflows/local-online-installer/main.tf
@@ -30,7 +30,7 @@ resource "google_compute_instance" "vm_instance_local_online_install" {
 
   boot_disk {
     initialize_params {
-      image = "rhel-8"
+      image = "rhel-9"
       size  = 100
     }
   }

--- a/.github/workflows/remote-offline-installer/main.tf
+++ b/.github/workflows/remote-offline-installer/main.tf
@@ -30,7 +30,7 @@ resource "google_compute_instance" "vm_instance_remote_offline_install" {
 
   boot_disk {
     initialize_params {
-      image = "rhel-8"
+      image = "rhel-9"
       size  = 100
     }
   }

--- a/.github/workflows/remote-online-installer/main.tf
+++ b/.github/workflows/remote-online-installer/main.tf
@@ -30,7 +30,7 @@ resource "google_compute_instance" "vm_instance_remote_online_install" {
 
   boot_disk {
     initialize_params {
-      image = "rhel-8"
+      image = "rhel-9"
       size  = 100
     }
   }

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ CLIENT ?= podman
 all:
 
 build-golang-executable:
-	sudo $(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.16 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.16 go build -v \
 	-ldflags "-X github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE} -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.postgresImage=${POSTGRES_IMAGE}'" \
 	-o mirror-registry;
 
 build-online-zip: 
-	sudo $(CLIENT) build \
+	$(CLIENT) build \
 		-t mirror-registry-online:${RELEASE_VERSION} \
 		--build-arg RELEASE_VERSION=${RELEASE_VERSION} \
 		--build-arg QUAY_IMAGE=${QUAY_IMAGE} \
@@ -21,11 +21,11 @@ build-online-zip:
 		--build-arg REDIS_IMAGE=${REDIS_IMAGE} \
 		--build-arg PAUSE_IMAGE=${PAUSE_IMAGE} \
 		--file Dockerfile.online . 
-	sudo $(CLIENT) run --name mirror-registry-online-${RELEASE_VERSION} mirror-registry-online:${RELEASE_VERSION}
-	sudo $(CLIENT) cp mirror-registry-online-${RELEASE_VERSION}:/mirror-registry.tar.gz .
+	$(CLIENT) run --name mirror-registry-online-${RELEASE_VERSION} mirror-registry-online:${RELEASE_VERSION}
+	$(CLIENT) cp mirror-registry-online-${RELEASE_VERSION}:/mirror-registry.tar.gz .
 
 build-offline-zip: 
-	sudo $(CLIENT) build \
+	$(CLIENT) build \
 		-t mirror-registry-offline:${RELEASE_VERSION} \
 		--build-arg RELEASE_VERSION=${RELEASE_VERSION} \
 		--build-arg QUAY_IMAGE=${QUAY_IMAGE} \
@@ -36,8 +36,8 @@ build-offline-zip:
 		--build-arg REDIS_IMAGE=${REDIS_IMAGE} \
 		--build-arg PAUSE_IMAGE=${PAUSE_IMAGE} \
 		--file Dockerfile .
-	sudo $(CLIENT) run --name mirror-registry-offline-${RELEASE_VERSION} mirror-registry-offline:${RELEASE_VERSION}
-	sudo $(CLIENT) cp mirror-registry-offline-${RELEASE_VERSION}:/mirror-registry.tar.gz .
+	$(CLIENT) run --name mirror-registry-offline-${RELEASE_VERSION} mirror-registry-offline:${RELEASE_VERSION}
+	$(CLIENT) cp mirror-registry-offline-${RELEASE_VERSION}:/mirror-registry.tar.gz .
 
 clean:
 	rm -rf mirror-registry* image-archive.tar

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This application will allow user to easily install Quay and its required compone
 
 - RHEL 8 or Fedora machine with `podman v3.3` and `openssl` installed
 - Fully qualified domain name for the Quay service (must resolve via DNS, or at least [/etc/hosts](#local-dns-resolution))
-- Passwordless `sudo` access on the target host (rootless install tbd)
 - Key-based SSH connectivity on the target host (will be set up automatically for local installs, in case of remote hosts see [here](#generate-ssh-keys))
 - `make` (only if [compiling](#compile-your-own-installer) your own installer)
 
@@ -31,7 +30,9 @@ The following flags are also available:
 --initPassword          The password of the init user created during Quay installation. If not specified, this will be randomly generated.
 --initUser              The username of the init user created during Quay installation. This defaults to init.
 --quayHostname          The value to set SERVER_HOSTNAME in the Quay config.yaml. This defaults to <targetHostname>:8443.
---quayRoot          -r  The folder where quay persistent data are saved. This defaults to /etc/quay-install.
+--quayRoot          -r  The folder where quay persistent quay config data is saved. This defaults to $HOME/quay-install.
+--quayStorage           The folder where quay persistent storage data is saved. This defaults to a Podman named volume 'quay-storage'. Root is required to uninstall.
+--pgStorage             The folder where postgres persistent storage data is saved. This defaults to a Podman named volume 'pg-storage'. Root is required to uninstall.
 --ssh-key           -k  The path of your ssh identity key. This defaults to ~/.ssh/quay_installer.
 --sslCert               The path to the SSL certificate Quay should use.
 --sslCheckSkip          Whether or not to check the certificate hostname against the SERVER_HOSTNAME in config.yaml.
@@ -65,7 +66,7 @@ This command will make the following changes to your machine
 - Generate trusted SSH keys, if not supplied, in case the deployment target is the local host (required since the installer is ansible-based)
 - Pulls Quay, Redis, and Postgres images from `registry.redhat.io` (if using online installer)
 - Sets up systemd files on host machine to ensure that container runtimes are persistent
-- Creates the folder defined by `--quayRoot` (default: `/etc/quay-install`) contains install files, local storage, and config bundle.
+- Creates the folder defined by `--quayRoot` (default: `$HOME/quay-install`) contains install files, local storage, and config bundle.
 - Installs Quay and creates an initial user called `init` with an auto-generated password
 - Access credentials are printed at the end of the install routine
 

--- a/ansible-runner/context/app/project/install_mirror_appliance.yml
+++ b/ansible-runner/context/app/project/install_mirror_appliance.yml
@@ -1,6 +1,5 @@
 - name: "Install Mirror Appliance"
   gather_facts: yes
-  become: true
   hosts: all
   tags:
     - quay

--- a/ansible-runner/context/app/project/roles/mirror_appliance/defaults/main.yml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 quay_hostname: "quay:8443"
-quay_root: "/etc/quay-install"
+quay_root: "$HOME/quay-install"
+quay_storage: "quay-storage"
+pg_storage: "pg-storage"
 auto_approve: "false"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-deps.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-deps.yaml
@@ -1,6 +1,4 @@
-- name: Add IP address of all hosts to all hosts
-  lineinfile:
-    dest: /etc/hosts
-    regexp: '.*{{ quay_hostname.split(":")[0] if (":" in quay_hostname) else quay_hostname }}$'
-    line: '127.0.0.1 {{ quay_hostname.split(":")[0] if (":" in quay_hostname) else quay_hostname }}'
-    state: present
+- name: Create user service directory
+  file:
+    path: $HOME/.config/systemd/user
+    state: directory

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-pod-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-pod-service.yaml
@@ -1,7 +1,7 @@
 - name: Copy Quay Pod systemd service file
   template:
     src: ../templates/pod.service.j2
-    dest: /etc/systemd/system/quay-pod.service
+    dest: $HOME/.config/systemd/user/quay-pod.service
 
 - name: Check if pod pause image is loaded
   command: podman inspect --type=image {{ pause_image }}
@@ -21,3 +21,4 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-postgres-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-postgres-service.yaml
@@ -1,19 +1,23 @@
 - name: Create necessary directory for Postgres persistent data
   ansible.builtin.file:
-    path: "{{ quay_root }}/pg-data"
+    path: "{{ pg_storage }}"
     state: directory
     recurse: yes
+  when: "pg_storage.startswith('/')"
 
-- name: Set permissions on data directory
+- name: Set permissions on local storage directory
   ansible.posix.acl:
-    path: "{{ quay_root }}/pg-data"
-    entry: u:26:-wx
+    path: "{{ pg_storage }}"
+    entity: 26
+    etype: user
+    permissions: wx
     state: present
+  when: "pg_storage.startswith('/')"
 
 - name: Copy Postgres systemd service file
   template:
     src: ../templates/postgres.service.j2
-    dest: /etc/systemd/system/quay-postgres.service
+    dest: $HOME/.config/systemd/user/quay-postgres.service
 
 - name: Check if Postgres image is loaded
   command: podman inspect --type=image {{ postgres_image }}
@@ -27,12 +31,18 @@
   retries: 5
   delay: 5
 
+- name: Create Postgres Storage named volume
+  containers.podman.podman_volume:
+      state: present
+      name: pg-storage
+
 - name: Start Postgres service
   systemd:
     name: quay-postgres.service
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user
 
 - name: Wait for pg_trgm to be installed
   command: podman exec -it quay-postgres /bin/bash -c "echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql -d quay -U postgres"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
@@ -1,20 +1,24 @@
 - name: Create necessary directory for Quay local storage
   ansible.builtin.file:
-    path: "{{ quay_root }}/quay-storage"
+    path: "{{ quay_storage }}"
     state: directory
     recurse: yes
+  when: "quay_storage.startswith('/')"
+
+- name: Set permissions on local storage directory
+  ansible.posix.acl:
+    path: "{{ quay_storage }}"
+    entity: 1001
+    etype: user
+    permissions: wx
+    state: present
+  when: "quay_storage.startswith('/')"
 
 - name: Create necessary directory for Quay config bundle
   ansible.builtin.file:
     path: "{{ quay_root }}/quay-config"
     state: directory
     recurse: yes
-
-- name: Set permissions on local storage directory
-  ansible.posix.acl:
-    path: "{{ quay_root }}/quay-storage"
-    entry: u:1001:-wx
-    state: present
 
 - name: Copy Quay config.yaml file
   template:
@@ -87,20 +91,16 @@
       ansible.builtin.file:
         path: "{{ quay_root }}/quay-config/ssl.key"
         mode: u=rw,g=r,o=r
-        owner: root
-        group: root
 
     - name: Set permissions for cert
       ansible.builtin.file:
         path: "{{ quay_root }}/quay-config/ssl.cert"
         mode: u=rw,g=r,o=r
-        owner: root
-        group: root
 
 - name: Copy Quay systemd service file
   template:
     src: ../templates/quay.service.j2
-    dest: /etc/systemd/system/quay-app.service
+    dest: $HOME/.config/systemd/user/quay-app.service
 
 - name: Check if Quay image is loaded
   command: podman inspect --type=image {{ quay_image }}
@@ -114,9 +114,15 @@
   retries: 5
   delay: 5
 
+- name: Create Quay Storage named volume
+  containers.podman.podman_volume:
+      state: present
+      name: quay-storage
+
 - name: Start Quay service
   systemd:
     name: quay-app.service
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-redis-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-redis-service.yaml
@@ -1,7 +1,7 @@
 - name: Copy Redis systemd service file
   template:
     src: ../templates/redis.service.j2
-    dest: /etc/systemd/system/quay-redis.service
+    dest: $HOME/.config/systemd/user/quay-redis.service
 
 - name: Check if Redis image is loaded
   command: podman inspect --type=image {{ redis_image }}
@@ -21,3 +21,4 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-pod-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-pod-service.yaml
@@ -1,7 +1,7 @@
 - name: Copy Quay Pod systemd service file
   template:
     src: ../templates/pod.service.j2
-    dest: /etc/systemd/system/quay-pod.service
+    dest: $HOME/.config/systemd/user/quay-pod.service
 
 - name: Check if pod pause image is loaded
   command: podman inspect --type=image {{ pause_image }}
@@ -21,3 +21,4 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-postgres-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-postgres-service.yaml
@@ -1,7 +1,7 @@
 - name: Copy Postgres systemd service file
   template:
     src: ../templates/postgres.service.j2
-    dest: /etc/systemd/system/quay-postgres.service
+    dest: $HOME/.config/systemd/user/quay-postgres.service
 
 - name: Check if Postgres image is loaded
   command: podman inspect --type=image {{ postgres_image }}
@@ -21,3 +21,4 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-quay-service.yaml
@@ -1,7 +1,7 @@
 - name: Copy Quay systemd service file
   template:
     src: ../templates/quay.service.j2
-    dest: /etc/systemd/system/quay-app.service
+    dest: $HOME/.config/systemd/user/quay-app.service
 
 - name: Check if Quay image is loaded
   command: podman inspect --type=image {{ quay_image }}
@@ -21,3 +21,4 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-redis-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-redis-service.yaml
@@ -1,7 +1,7 @@
 - name: Copy Redis systemd service file
   template:
     src: ../templates/redis.service.j2
-    dest: /etc/systemd/system/quay-redis.service
+    dest: $HOME/.config/systemd/user/quay-redis.service
 
 - name: Check if Redis image is loaded
   command: podman inspect --type=image {{ redis_image }}
@@ -21,3 +21,4 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+    scope: user

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/postgres.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/postgres.service.j2
@@ -10,7 +10,7 @@ TimeoutStartSec=5m
 ExecStartPre=-/bin/rm -f %t/%n-pid %t/%n-cid
 ExecStart=/usr/bin/podman run \
     --name quay-postgres \
-    -v {{ quay_root }}/pg-data:/var/lib/pgsql/data:Z \
+    -v {{ pg_storage }}:/var/lib/pgsql/data:Z \
     -e POSTGRESQL_USER=user \
     -e POSTGRESQL_PASSWORD=password \
     -e POSTGRESQL_DATABASE=quay \

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
@@ -11,7 +11,7 @@ ExecStartPre=-/bin/rm -f %t/%n-pid %t/%n-cid
 ExecStart=/usr/bin/podman run \
     --name quay-app \
     -v {{ quay_root }}/quay-config:/quay-registry/conf/stack:Z \
-    -v {{ quay_root }}/quay-storage:/datastorage:Z \
+    -v {{ quay_storage }}:/datastorage:Z \
     --pod=quay-pod \
     --conmon-pidfile %t/%n-pid \
     --cidfile %t/%n-cid \

--- a/ansible-runner/context/app/project/uninstall_mirror_appliance.yml
+++ b/ansible-runner/context/app/project/uninstall_mirror_appliance.yml
@@ -1,6 +1,5 @@
 - name: "Uninstall Mirror Appliance"
   gather_facts: yes
-  become: true
   hosts: all
   tags:
     - quay
@@ -13,6 +12,7 @@
         daemon_reload: yes
         state: stopped
         force: yes
+        scope: user
 
     - name: Stop Redis service
       systemd:
@@ -21,6 +21,7 @@
         daemon_reload: yes
         state: stopped
         force: yes
+        scope: user
 
     - name: Stop Postgres service
       systemd:
@@ -29,6 +30,7 @@
         daemon_reload: yes
         state: stopped
         force: yes
+        scope: user
 
     - name: Stop Quay Pod service
       systemd:
@@ -37,6 +39,7 @@
         daemon_reload: yes
         state: stopped
         force: yes
+        scope: user
 
     - name: Delete pod
       containers.podman.podman_pod:
@@ -49,10 +52,36 @@
         path: "{{ quay_root }}"
       when: auto_approve|bool == true
 
+    - name: Create Quay Storage named volume
+      containers.podman.podman_volume:
+          state: absent
+          name: quay-storage
+      when: auto_approve|bool == true and quay_storage == "pg-storage"
+
+    - name: Delete Postgres Storage named volume
+      containers.podman.podman_volume:
+          state: absent
+          name: pg-storage
+      when: auto_approve|bool == true and pg_storage == "pg-storage"
+
+    - name: Delete necessary directory for Quay local storage
+      ansible.builtin.file:
+        path: "{{ quay_storage }}"
+        state: absent
+      become: yes
+      when: auto_approve|bool == true and quay_storage.startswith('/')
+
+    - name: Delete necessary directory for Postgres persistent data
+      ansible.builtin.file:
+        path: "{{ pg_storage }}"
+        state: absent
+      become: yes
+      when: auto_approve|bool == true and pg_storage.startswith('/')
+
     - name: Cleanup systemd unit files
       file:
         state: absent
-        path: "/etc/systemd/system/{{ item }}"
+        path: "$HOME/.config/systemd/user/{{ item }}"
       loop:
         - quay-pod.service
         - quay-postgres.service
@@ -62,3 +91,4 @@
     - name: Just force systemd to reread configs (2.4 and above)
       ansible.builtin.systemd:
         daemon_reload: yes
+        scope: user

--- a/ansible-runner/context/app/project/upgrade_mirror_appliance.yml
+++ b/ansible-runner/context/app/project/upgrade_mirror_appliance.yml
@@ -1,6 +1,5 @@
 - name: "Upgrade Mirror Appliance"
   gather_facts: yes
-  become: true
   hosts: all
   tags:
     - quay

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -186,14 +186,14 @@ func getImageMetadata(app, imageName, archivePath string) string {
 
 	switch app {
 	case "pause":
-		statement = `sudo /usr/bin/podman image import \
+		statement = `/usr/bin/podman image import \
 					--change 'ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
 					--change 'ENV container=oci' \
 					--change 'ENTRYPOINT=["sleep"]' \
 					--change 'CMD=["infinity"]' \
 					- ` + imageName + ` < ` + archivePath
 	case "ansible":
-		statement = `sudo /usr/bin/podman image import \
+		statement = `/usr/bin/podman image import \
 					--change 'ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
 					--change 'ENV HOME=/home/runner' \
 					--change 'ENV container=oci' \
@@ -204,7 +204,7 @@ func getImageMetadata(app, imageName, archivePath string) string {
 					--change 'CMD ["ansible-runner", "run", "/runner"]' \
 					- ` + imageName + ` < ` + archivePath
 	case "redis":
-		statement = `sudo /usr/bin/podman image import \
+		statement = `/usr/bin/podman image import \
 					--change 'ENV PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
 					--change 'ENV container=oci' \
 					--change 'ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i' \
@@ -224,7 +224,7 @@ func getImageMetadata(app, imageName, archivePath string) string {
 					--change 'CMD ["run-redis"]' \
 					- ` + imageName + ` < ` + archivePath
 	case "postgres":
-		statement = `sudo /usr/bin/podman image import \
+		statement = `/usr/bin/podman image import \
 					--change 'ENV PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
 					--change 'ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i' \
 					--change 'ENV STI_SCRIPTS_PATH=/usr/libexec/s2i' \
@@ -245,7 +245,7 @@ func getImageMetadata(app, imageName, archivePath string) string {
 	case "quay":
 		// quay.io
 		quayVersion := strings.Split(imageName, ":")[1]
-		statement = `sudo /usr/bin/podman image import \
+		statement = `/usr/bin/podman image import \
 					--change 'ENV PATH=/.local/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' \
 					--change 'ENV RED_HAT_QUAY=true' \
 					--change 'ENV PYTHON_VERSION=3.8' \


### PR DESCRIPTION
* Removes requirements for `root`
* Updates default `quay-install` location to be in a user writeable directory, `$HOME/quay-install`
  * Users can use the `--quayRoot`, `--quayStorage` and `pgStorage` flags to change install location, but previous root requirement is needed. 
  *Example: `$ ./mirror-registry install -v --quayRoot /home/doconnor/quay-install --quayStorage /home/doconnor/quay-install/quay-storage --pgStorage /home/doconnor/quay-install/pg-data` 
* Stores postgres data in new podman named volume `quay-postgres-data`
* Removes actions that require `/etc/hosts` to be updated
  * Only root users can update `/etc/hosts`, this is incompatible with a rootless install
* Also works on RHEL9 ([PROJQUAY-3084](https://issues.redhat.com/browse/PROJQUAY-3084))
* Updates `mirror-registry` to `v1.3.0` and includes Quay 3.8.0 for IPv6 support
```
[doconnor@doconnor-omr-dev-rhel9 ~]$ cat /etc/redhat-release
Red Hat Enterprise Linux release 9.1 (Plow)
[doconnor@doconnor-omr-dev-rhel9 ~]$ podman --version
podman version 4.2.0
[doconnor@doconnor-omr-dev-rhel9 ~]$ systemctl --user status quay-app
● quay-app.service - Quay Container
     Loaded: loaded (/home/doconnor/.config/systemd/user/quay-app.service; enabled; vendor preset: disabled)
     Active: active (running) since Mon 2022-12-19 13:55:52 UTC; 4min 59s ago
    Process: 67021 ExecStartPre=/bin/rm -f /run/user/1007/quay-app.service-pid /run/user/1007/quay-app.service-cid (code=exited, status=0/SUCCESS)
```