### PR TITLE
Fix CI /etc/hosts permissions (PROJQUAY-0000)

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -148,7 +148,7 @@ jobs:
         run: tar -xf mirror-registry.tar.gz
       
       - name: Add quay to /etc/hosts
-        run: ssh jonathan@quay 'sudo echo "127.0.0.1 quay" >> /etc/hosts'
+        run: ssh jonathan@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
 
       - name: Install podman
         run: ssh jonathan@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
@@ -252,7 +252,7 @@ jobs:
         run: scp mirror-registry.tar.gz jonathan@quay:~/mirror-registry.tar.gz
 
       - name: Add quay to /etc/hosts
-        run: ssh jonathan@quay 'sudo echo "127.0.0.1 quay" >> /etc/hosts'
+        run: ssh jonathan@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
 
       - name: Install podman
         run: ssh jonathan@quay 'sudo subscription-manager refresh; sudo yum -y install podman'


### PR DESCRIPTION
Should resolve error:

```
Run ssh jonathan@quay 'sudo echo "127.0.0.1 quay" >> /etc/hosts'
Warning: Permanently added 'quay' (ED25519) to the list of known hosts.
bash: line 1: /etc/hosts: Permission denied
Error: Process completed with exit code 1.
```