### PR TITLE
Adjust UMASK before creating SSH authorized_keys file

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -93,7 +93,7 @@ func setupLocalSSH() error {
 	}
 
 	log.Infof("Adding key to ~/.ssh/authorized_keys")
-	cmd = exec.Command("bash", "-c", "/bin/echo \""+string(keyFile)+"\" >> ~/.ssh/authorized_keys")
+	cmd = exec.Command("bash", "-c", "umask 066 && /bin/echo \""+string(keyFile)+"\" >> ~/.ssh/authorized_keys")
 	if verbose {
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
**TLDR:** Defaults on some systems can cause umask to be too permissive, make sure to set umask before attempting to add SSH key to authorized_keys file in case where that file doesn't exists yet.

---

On some systems the default UMASK might be too permissive. For example on RHEL 8.7 minimal installation:
~~~
root@ # umask
0022
~~~
~~~
user@ # umask
0002
~~~
During the installation `mirror-registry` will add SSH key at the end of `~/.ssh/authorized_keys`. However if the file doesn't exists it will get created and at that time the UMASK will limit what permissions the file will receive. For comparison results of installation with version 1.3.2 as root and as user:
~~~
# ls -l /root/.ssh/
total 12
-rw-r--r--. 1 root root  406 Mar 27 16:21 authorized_keys
-rw-------. 1 root root 1831 Mar 27 16:21 quay_installer
-rw-r--r--. 1 root root  405 Mar 27 16:21 quay_installer.pub
~~~
~~~
$ ls -l /home/test/.ssh/
total 12
-rw-rw-r--. 1 test test  406 Mar 27 16:25 authorized_keys
-rw-------. 1 test test 1831 Mar 27 16:25 quay_installer
-rw-r--r--. 1 test test  405 Mar 27 16:25 quay_installer.pub
~~~
Note that for user `test` above the installation will fail with error bellow and sshd logs will contain message suggesting permissions or ownership of authorized_keys file is bad.
~~~
# /tmp/mirror-registry/mirror-registry install --quayHostname quay.local
...
TASK [Gathering Facts] ********************************************************************************************************
fatal: [test@fastvm-rhel-8-7-32]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added 'fastvm-rhel-8-7-32,192.168.4.32' (ECDSA) to the list of known hosts.\r\ntest@fastvm-rhel-8-7-32: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).", "unreachable": true}

PLAY RECAP ********************************************************************************************************************
test@fastvm-rhel-8-7-32    : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0

ERRO[2023-03-27 16:25:37] An error occurred: exit status 4
~~~
~~~
# journalctl -u sshd|grep refused
Mar 27 16:25:36 fastvm-rhel-8-7-32 sshd[19793]: Authentication refused: bad ownership or modes for file /home/test/.ssh/authorized_keys
~~~

Change proposed in this PR will set umask to filter read+write permissions for "Group and Others" resulting in file that SSHd can accept. Issue was discovered while testing non-root installation. With change introduced in this PR the installation as non-root user proceeds as excepted on RHEL 8.7 and `~/.ssh/authorized_keys` has expected tight permissions.
~~~
# ls -l /home/test/.ssh/authorized_keys
-rw-------. 1 test test 406 Mar 27 16:27 /home/test/.ssh/authorized_keys
~~~
~~~
# grep quay /etc/hosts
127.0.0.1 quay.local
~~~
