### PR TITLE
specify required permissions on quay configuration files (PROJQUAY-6517)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
@@ -17,6 +17,7 @@
 - name: Create necessary directory for Quay config bundle
   ansible.builtin.file:
     path: "{{ quay_root }}/quay-config"
+    mode: 0750
     state: directory
     recurse: yes
 
@@ -24,6 +25,7 @@
   template:
     src: ../templates/config.yaml.j2
     dest: "{{ quay_root }}/quay-config/config.yaml"
+    mode: 0750
 
 - name: Check if SSL Cert exists
   stat:
@@ -42,6 +44,7 @@
     - name: Create necessary directory for Quay rootCA files
       ansible.builtin.file:
         path: "{{ quay_root }}/quay-rootCA"
+        mode: 0750
         state: directory
         recurse: yes
         


### PR DESCRIPTION
As mentioned in https://github.com/quay/mirror-registry/issues/136 with a hardened RHEL 8 instance with global umask of `0077` the mirror-registry fails to install, due to the quay pod not being able to access the `{{ quay_root }}/quay-config` directory.

This PR adds explicit mode for the directory and `config.yaml` to allow a successful offline quay install with mirror-registry on a hardened environment.