### PR TITLE
Set RELEASE_VERSION via git tag (PROJQUAY-6394)

### DIFF
--- a/.env
+++ b/.env
@@ -4,5 +4,4 @@ EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-build
 POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-10:1-203.1669834630
 QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.8.12
 REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-92.1669834635
-RELEASE_VERSION=v1.3.9
 PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:8.7-6

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -1,6 +1,9 @@
 name: "Release"
 
 on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request_target:
     types: [labeled]
     branches:
@@ -65,7 +68,7 @@ jobs:
         run: sudo pip install ansible-builder
 
       - name: Build tarfile
-        run: CLIENT=docker make build-${{ matrix.installer-type }}-zip
+        run: CLIENT=docker RELEASE_VERSION=${{ github.ref_name }} make build-${{ matrix.installer-type }}-zip
 
       - name: Upload tarfile
         uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 include .env
 
 CLIENT ?= podman
+# RELEASE_VERSION is overridden in CI as the git tag matching format v[0-9]+.[0-9]+.[0-9]+
+RELEASE_VERSION ?= dev
 
 all:
 


### PR DESCRIPTION
See https://github.com/HammerMeetNail/actions_test/actions/workflows/main.yml for working examples. 

* Configures CI to build when a tag matching is pushed
* Sets `RELEASE_VERSION` via the git tag instead of in `.env`
* This change requires a change in the midstream to use the git tag since `RELEASE_VERSION` is no longer committed to the repo