### PR TITLE
fix some issues around secrets handling (PROJQUAY-6787)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-postgres-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-postgres-service.yaml
@@ -36,6 +36,12 @@
       state: present
       name: pg-storage
 
+- name: Create Postgres Password Secret
+  containers.podman.podman_secret:
+    state: present
+    name: pgdb_pass
+    data: "{{ pgdb_password }}"
+
 - name: Start Postgres service
   systemd:
     name: quay-postgres.service

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-postgres-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-postgres-service.yaml
@@ -41,6 +41,7 @@
     state: present
     name: pgdb_pass
     data: "{{ pgdb_password }}"
+    skip_existing: true
 
 - name: Start Postgres service
   systemd:

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-redis-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-redis-service.yaml
@@ -15,6 +15,12 @@
   retries: 5
   delay: 5
 
+- name: Create Redis Password Secret
+  containers.podman.podman_secret:
+    state: present
+    name: redis_pass
+    data: "{{ redis_password }}"
+
 - name: Start Redis service
   systemd:
     name: quay-redis.service

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-redis-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-redis-service.yaml
@@ -20,6 +20,7 @@
     state: present
     name: redis_pass
     data: "{{ redis_password }}"
+    skip_existing: true
 
 - name: Start Redis service
   systemd:

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/main.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/main.yaml
@@ -1,6 +1,9 @@
 - name: Expand variables
   include_tasks: expand-vars.yaml
 
+- name: Create secret vars
+  include_tasks: secret-vars.yaml
+
 - name: Install Dependencies
   include_tasks: install-deps.yaml
 

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
@@ -1,0 +1,6 @@
+- name: Generate secrets for Quay config.yaml
+  set_fact:
+    secret_key: "{{ lookup('community.general.random_string', length=48, base64=True) }}"
+    database_secret_key: "{{ lookup('community.general.random_string', length=48, base64=True) }}"
+    pgdb_password: "{{ lookup('community.general.random_string', length=24, base64=True) }}"
+    redis_password: "{{ lookup('community.general.random_string', length=24, base64=True) }}"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/config.yaml.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/config.yaml.j2
@@ -1,10 +1,10 @@
 AUTHENTICATION_TYPE: Database
 BUILDLOGS_REDIS:
   host: localhost
-  password: password
+  password: {{ redis_password }}
   port: 6379
-DATABASE_SECRET_KEY: "81541057085600720484162638317561463611194901378275494293746615390984668417511"
-DB_URI: postgresql://user:password@localhost/quay
+DATABASE_SECRET_KEY: {{ database_secret_key }}
+DB_URI: postgresql://user:{{ pgdb_password }}@localhost/quay
 DEFAULT_TAG_EXPIRATION: 2w
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
 DISTRIBUTED_STORAGE_PREFERENCE:
@@ -42,7 +42,7 @@ REGISTRY_TITLE: Red Hat Quay
 REGISTRY_TITLE_SHORT: Red Hat Quay
 REPO_MIRROR_SERVER_HOSTNAME: null
 REPO_MIRROR_TLS_VERIFY: false
-SECRET_KEY: "30824339799025335633887256663000123118247018465144108496567331049820667127217"
+SECRET_KEY: {{ secret_key }}
 SECURITY_SCANNER_ISSUER_NAME: security_scanner
 SERVER_HOSTNAME: {{ quay_hostname }}
 SETUP_COMPLETE: true
@@ -60,7 +60,7 @@ USERFILES_LOCATION: default
 USERFILES_PATH: userfiles/
 USER_EVENTS_REDIS:
   host: localhost
-  password: password
+  password: {{ redis_password }}
   port: 6379
 USE_CDN: false
 FEATURE_USER_INITIALIZE: true

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/postgres.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/postgres.service.j2
@@ -13,12 +13,12 @@ ExecStart=/usr/bin/podman run \
     -v {{ expanded_pg_storage }}:/var/lib/pgsql/data:Z \
     --image-volume=ignore \
     -e POSTGRESQL_USER=user \
-    -e POSTGRESQL_PASSWORD=password \
     -e POSTGRESQL_DATABASE=quay \
     --pod=quay-pod \
     --conmon-pidfile %t/%n-pid \
     --cidfile %t/%n-cid \
     --cgroups=no-conmon \
+    --secret=pgdb_pass,type=env,target=POSTGRESQL_PASSWORD \
     --replace \
     {{ postgres_image }}
 

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/redis.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/redis.service.j2
@@ -10,12 +10,12 @@ TimeoutStartSec=5m
 ExecStartPre=-/bin/rm -f %t/%n-pid %t/%n-cid
 ExecStart=/usr/bin/podman run \
     --name quay-redis \
-    -e REDIS_PASSWORD=password \
     --pod=quay-pod \
     --conmon-pidfile %t/%n-pid \
     --cidfile %t/%n-cid \
     --cgroups=no-conmon \
     --image-volume=ignore \
+    --secret=redis_pass,type=env,target=REDIS_PASSWORD \
     --replace \
     {{ redis_image }}
 


### PR DESCRIPTION
Hi team,

# What

I noticed that the current `config.yaml.j2` contains some hard-coded secrets, and confirmed in an internal environment that they were unchanged as part of the `mirror-registry` deployment process.

# Why

I believe users of mirror-registry will want unique passwords & secrets, most importantly the CSRF `SECRET_KEY` since that has significant implications on session hijacking.

# How

1. Add new task `secret-vars.yaml` that will generate random strings using the already imported `community.general.random_string` library.
2. Export those secrets as facts
3. Update the `config.yaml.j2` to use those facts as part of deployment
4. Update `install-postgres-service.yaml` and `install-redis-service.yaml` to create podman secrets using the facts
5. Update `postgres.service.j2` and `redis.service.j2` to utilize the secrets created

This will not impact upgrades, only initial deployments.

I've done the DCO sign-off, and believe this PR is ready to merge, however I'm happy to update/modify based on feedback from this team.

Cheers,

-BadgerOps