### PR TITLE
add delete password option to mirror registry uninstall

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/uninstall.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/uninstall.yaml
@@ -51,6 +51,16 @@
       name: pg-storage
   when: auto_approve|bool == true and pg_storage == "pg-storage"
 
+- name: Delete Postgres Password Secret
+  containers.podman.podman_secret:
+    state: absent
+    name: pgdb_pass
+
+- name: Delete Redis Password Secret
+  containers.podman.podman_secret:
+    state: absent
+    name: redis_pass
+
 - name: Delete necessary directory for Quay local storage
   ansible.builtin.file:
     path: "{{ quay_storage }}"


### PR DESCRIPTION
Hey all,

I missed an important task with the previous PR - _removing the passwords on uninstall_ 

This PR fixes that, I tested with install/uninstall and install/upgrade/uninstall. Everything worked fine.

Incidentally, `Quay v3.10.4` can drop into `.env` without a (noticeable) problem! The upgrade & image post post upgrade worked fine.

Cheers,

-BadgerOps