### PR TITLE
Avoid special symbols in passwords

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
@@ -2,5 +2,5 @@
   set_fact:
     secret_key: "{{ lookup('community.general.random_string', length=48, base64=True) }}"
     database_secret_key: "{{ lookup('community.general.random_string', length=48, base64=True) }}"
-    pgdb_password: "{{ lookup('community.general.random_string', length=24, base64=True) }}"
-    redis_password: "{{ lookup('community.general.random_string', length=24, base64=True) }}"
+    pgdb_password: "{{ lookup('community.general.random_string', length=24, special=False) }}"
+    redis_password: "{{ lookup('community.general.random_string', length=24, special=False) }}"


### PR DESCRIPTION
Some special characters may cause issues in DB URI unless they are properly escaped. For example, the password "ab/cd" cannot be used directly in the URI

    postgresql://user:ab/cd@localhost/quay

because netloc became "user:ab", while we want it to be "user:ab/cd@localhost".