### PR TITLE
fix: update script to create podman secrets from existing config.yaml

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
@@ -11,9 +11,8 @@
   ansible.builtin.set_fact:
     quay_config_file: "{{ remote_yaml_file['content'] | b64decode | from_yaml }}"
 
-- name: Set facts for the DATABASE_SECRET_KEY, USER_EVENTS_REDIS['password'] and Postgres password derived from DB_URI only if they are a string and not a jinja2 variable in the config.yaml.
+- name: Set facts for the pre-existing secrets only if they are a string and not a jinja2 variable in the config.yaml.
   ansible.builtin.set_fact:
-    DATABASE_SECRET_KEY : "{{ quay_config_file['DATABASE_SECRET_KEY'] }}"
     REDIS_PASSWORD : "{{ quay_config_file['USER_EVENTS_REDIS']['password'] }}"
     PGDB_PASSWORD : "{{ quay_config_file['DB_URI'].split('@')[0].split(':')[2] }}"
   when: quay_config_file['DATABASE_SECRET_KEY'] is string and quay_config_file['USER_EVENTS_REDIS']['password'] is string and quay_config_file['DB_URI'] is string

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
@@ -1,0 +1,19 @@
+- name: Look up quay_root, set it to /etc/quay-install if not found.
+  ansible.builtin.set_fact:
+    quay_root: "{{ quay_root | default('/etc/quay-install') }}"
+
+- name: Include vars of the config.yaml into the 'quay_config_file' variable.
+  ansible.builtin.slurp:
+    src: "{{ quay_root }}/quay-config/config.yaml"
+  register: remote_yaml_file
+
+- name: Parse the remote YAML file and set as a fact
+  ansible.builtin.set_fact:
+    quay_config_file: "{{ remote_yaml_file['content'] | b64decode | from_yaml }}"
+
+- name: Set facts for the DATABASE_SECRET_KEY, USER_EVENTS_REDIS['password'] and Postgres password derived from DB_URI only if they are a string and not a jinja2 variable in the config.yaml.
+  ansible.builtin.set_fact:
+    DATABASE_SECRET_KEY : "{{ quay_config_file['DATABASE_SECRET_KEY'] }}"
+    REDIS_PASSWORD : "{{ quay_config_file['USER_EVENTS_REDIS']['password'] }}"
+    PGDB_PASSWORD : "{{ quay_config_file['DB_URI'].split('@')[0].split(':')[2] }}"
+  when: quay_config_file['DATABASE_SECRET_KEY'] is string and quay_config_file['USER_EVENTS_REDIS']['password'] is string and quay_config_file['DB_URI'] is string

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-postgres-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-postgres-service.yaml
@@ -15,6 +15,13 @@
   retries: 5
   delay: 5
 
+- name: Create Postgres Password Secret
+  containers.podman.podman_secret:
+    state: present
+    name: pgdb_pass
+    data: "{{ PGDB_PASSWORD }}"
+    skip_existing: true
+
 - name: Start Postgres service
   systemd:
     name: quay-postgres.service

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-redis-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-redis-service.yaml
@@ -15,6 +15,13 @@
   retries: 5
   delay: 5
 
+- name: Create Redis Password Secret
+  containers.podman.podman_secret:
+    state: present
+    name: redis_pass
+    data: "{{ REDIS_PASSWORD }}"
+    skip_existing: true
+
 - name: Start Redis service
   systemd:
     name: quay-redis.service

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
@@ -13,6 +13,9 @@
 - name: Autodetect Image Archive
   include_tasks: autodetect-image-archive.yaml
 
+- name: Autodetect existing Secrets in config.yaml
+  include_tasks: upgrade-config-vars.yaml
+
 - name: Upgrade Quay Pod Service
   include_tasks: upgrade-pod-service.yaml
 


### PR DESCRIPTION
Here's another resolution to [PROJQUAY-7001](https://issues.redhat.com//browse/PROJQUAY-7001)

* If we're running the upgrade script, check for `"{{ quay_root }}/quay-config/config.yaml"` and pull the passwords out and use the to create the podman secrets.

This is backwards compatible, and passes the test suite locally for me - happy to collaborate on any adjustments y'all think is necessary.

Logs from the upgrade test suite:

```
TASK [mirror_appliance : Autodetect existing Secrets in config.yaml] ******************************************************************************************************************
included: /runner/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml for root@fedora37

TASK [mirror_appliance : Look up quay_root, set it to /etc/quay-install if not found.] ************************************************************************************************
ok: [root@fedora37]

TASK [mirror_appliance : Include vars of the config.yaml into the 'quay_config_file' variable.] ***************************************************************************************
ok: [root@fedora37]

TASK [mirror_appliance : Parse the remote YAML file and set as a fact] ****************************************************************************************************************
ok: [root@fedora37]

TASK [mirror_appliance : Set facts for the DATABASE_SECRET_KEY, USER_EVENTS_REDIS['password'] and Postgres password derived from DB_URI only if they are a string and not a jinja2 variable in the config.yaml.] ***
ok: [root@fedora37]

<snip>

TASK [mirror_appliance : Create Postgres Password Secret] *****************************************************************************************************************************
changed: [root@fedora37]

< snip>

TASK [mirror_appliance : Create Redis Password Secret] ********************************************************************************************************************************
changed: [root@fedora37]

```

Then, to confirm:

```bash
[vagrant@fedora37 ~]$ sudo podman secret list
ID          NAME        DRIVER      CREATED     UPDATED
[vagrant@fedora37 ~]$ sudo podman secret list
ID                         NAME        DRIVER      CREATED         UPDATED
0071beb766a2156b8ab213f2f  redis_pass  file        29 seconds ago  29 seconds ago
008a56adfa1310a293db56b4e  pgdb_pass   file        31 seconds ago  31 seconds ago
[vagrant@fedora37 ~]$ sudo cat /var/lib/containers/storage/secrets/filedriver/secretsdata.json
{
  "0071beb766a2156b8ab213f2f": "cGFzc3dvcmQ=",
  "008a56adfa1310a293db56b4e": "cGFzc3dvcmQ="
```

And to verify:

```bash
[vagrant@fedora37 ~]$ echo -n 'cGFzc3dvcmQ=' | base64 -d -

password
```
