### PR TITLE
PROJQUAY-7424: Correct the quay_storage volume name in uninstalling task

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/uninstall.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/uninstall.yaml
@@ -43,7 +43,7 @@
   containers.podman.podman_volume:
       state: absent
       name: quay-storage
-  when: auto_approve|bool == true and quay_storage == "pg-storage"
+  when: auto_approve|bool == true and quay_storage == "quay-storage"
 
 - name: Delete Postgres Storage named volume
   containers.podman.podman_volume:


### PR DESCRIPTION
* Description: The "quay_storage" volume name in the uninstall task should be "quay-storage" for deleting the volume directory during uninstalling. Because the quay volume creates as "quay-storage" by default when installing. The volume name should be matched. Refer the following codes which show us the place holder of "quay_storage=%s" is "quay-storage" by default as well.
* References:
  - https://github.com/quay/mirror-registry/blob/26d82cea952998d643d53cc2c8248af6ea2e12b4/cmd/install.go#L102