### PR TITLE
chore: update ansible-automation-platform images

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 EE_IMAGE=quay.io/quay/mirror-registry-ee:latest
-EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-249
-EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-builder-rhel8:1.1.0-103
+EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-24/ee-minimal-rhel8:1.0.0-659
+EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-24/ansible-builder-rhel8:3.0.1-44
 POSTGRES_IMAGE=registry.redhat.io/rhel8/postgresql-10:1-203.1669834630
 QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.8.15
 REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-92.1669834635

--- a/ansible-runner/context/Containerfile
+++ b/ansible-runner/context/Containerfile
@@ -1,5 +1,5 @@
-ARG EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-128
-ARG EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-builder-rhel8:1.1.0-32
+ARG EE_BASE_IMAGE
+ARG EE_BUILDER_IMAGE
 
 FROM $EE_BASE_IMAGE as galaxy
 ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=

--- a/ansible-runner/execution-environment.yml
+++ b/ansible-runner/execution-environment.yml
@@ -1,9 +1,6 @@
 ---
 version: 1
 
-build_arg_defaults:
-  EE_BASE_IMAGE: registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-128
-
 dependencies:
   galaxy: requirements.yml
 


### PR DESCRIPTION
Ansible 2.2 has reached end of life on May 31, 2024. We should migrate to 2.4 to have a supported version.