### PR TITLE
CI: Remove passing ssh key for CI local install

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -341,7 +341,7 @@ jobs:
         run: ssh jonathan@quay 'tar -xzf mirror-registry-postgres.tar.gz -C ./mirror-registry-postgres'
 
       - name: Install postgres backed quay registry
-        run: ssh jonathan@quay './mirror-registry-postgres/mirror-registry install -u jonathan -r /home/jonathan/quay-install -H quay -v --initPassword password -k /home/runner/.ssh/id_rsa'
+        run: ssh jonathan@quay './mirror-registry-postgres/mirror-registry install -u jonathan -r /home/jonathan/quay-install -H quay:8443 -v --initPassword password'
 
       - name: Podman login to quay registry
         run: ssh jonathan@quay 'podman login -u init -p password quay:8443 --tls-verify=false'
@@ -356,7 +356,7 @@ jobs:
         run: ssh jonathan@quay 'podman push quay:8443/init/busybox:latest --tls-verify=false'
 
       - name: Use latest binary to test upgrade cmd to ensure db migration from old postgres to sqlite
-        run: ssh jonathan@quay './mirror-registry upgrade -u jonathan -r /home/jonathan/quay-install -H quay -v --initPassword password -k /home/runner/.ssh/id_rsa'
+        run: ssh jonathan@quay './mirror-registry upgrade -u jonathan -r /home/jonathan/quay-install -H quay:8443 -v --initPassword password'
 
       - name: Pull already pushed busybox image from quay registry
         run: ssh jonathan@quay 'podman pull quay:8443/init/busybox:latest --tls-verify=false'


### PR DESCRIPTION
ssh key is not needed for testing CI local install