### PR TITLE
Modify sqlite storage creation in ansible task (PROJQUAY-7663)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
@@ -14,14 +14,20 @@
     state: present
   when: "quay_storage.startswith('/')"
 
-- name: Create necessary directory for sqlite data
-  become_method: containers.podman.podman_unshare
-  become: true
+- name: Create necessary directory for sqlite storage
   ansible.builtin.file:
-    mode: u+rwx
-    owner: 1001
     path: "{{ sqlite_storage }}"
     state: directory
+    recurse: yes
+  when: "sqlite_storage.startswith('/')"
+
+- name: Set permissions on sqlite storage directory
+  ansible.posix.acl:
+    path: "{{ sqlite_storage }}"
+    entity: 1001
+    etype: user
+    permissions: wx
+    state: present
   when: "sqlite_storage.startswith('/')"
 
 - name: Create necessary directory for Quay config bundle

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-quay-service.yaml
@@ -23,14 +23,20 @@
   register: sqlite_storage_stat
   when: sqlite_storage.startswith('/')
 
-- name: Create necessary directory for sqlite data if it doesn't exist
-  become_method: containers.podman.podman_unshare
-  become: true
+- name: Create necessary directory for sqlite storage
   ansible.builtin.file:
-    mode: u+rwx
-    owner: 1001
     path: "{{ sqlite_storage }}"
     state: directory
+    recurse: yes
+  when: sqlite_storage.startswith('/') and not sqlite_storage_stat.stat.exists
+
+- name: Set permissions on sqlite storage directory
+  ansible.posix.acl:
+    path: "{{ sqlite_storage }}"
+    entity: 1001
+    etype: user
+    permissions: wx
+    state: present
   when: sqlite_storage.startswith('/') and not sqlite_storage_stat.stat.exists
 
 - name: Start Quay service


### PR DESCRIPTION
anisble plugin 'containers.podman.podman_unshare' is not being recognized, hence replacing it with ansible.builtin.file to create dir