### PR TITLE
Fix - Quay Storage Directory

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/install-quay-service.yaml
@@ -1,5 +1,6 @@
 - name: Create necessary directory for Quay local storage
   ansible.builtin.file:
+    mode: 0775
     path: "{{ quay_storage }}"
     state: directory
     recurse: yes


### PR DESCRIPTION
Currently if you run the installer with a user that does not have UID = 1000 and has a umask that is not 002 (e.g. 027) and quayStorage pointing to a (not yet) existing dir. The container wil not have permissions to write files in the directory. The commit should fix this.

The describe situation results in bad gateway 502 errors in when pushing to the registry. In the quay-app this results in various permission denied errors in the logs.