### PR TITLE
task: Do not remove Quay container on exit

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
@@ -8,6 +8,7 @@ Requires=quay-pod.service quay-redis.service
 Type=simple
 TimeoutStartSec=5m
 Environment=PODMAN_SYSTEMD_UNIT=%n
+ExecStartPre=-/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 ExecStartPre=-/bin/rm -f %t/%n-pid %t/%n-cid
 ExecStart=/usr/bin/podman run \
     --name quay-app \
@@ -26,7 +27,6 @@ ExecStart=/usr/bin/podman run \
     {{ quay_image }} {{ quay_cmd }}
     
 ExecStop=-/usr/bin/podman stop --ignore --cidfile %t/%n-cid -t 10
-ExecStopPost=-/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
 PIDFile=%t/%n-pid
 KillMode=none
 Restart=always


### PR DESCRIPTION
When Quay container starts via the systemd unit, it gets automatically removed as a post-stop action. This causes problems when trying to diagnose startup issues, such as any validation errors. Logs are written in journal and can be pulled out by `journalctl` but sometimes it's just easier to call container logs instead. With this change, we set the removal of Quay container, if it exists, as an `ExecStartPre` action. This allows the container to persist after exiting for additional debugging.