### PR TITLE
bug: retain indentation formatting in migration script (PROJQUAY-8360)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_to_sqlite.sh
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_to_sqlite.sh
@@ -33,9 +33,6 @@ pg_to_sqlite() {
     # Remove empty lines
     sql=$(echo "$sql" | sed "/^\s*$/d")
 
-    # Trim whitespace from the beginning and end
-    sql=$(echo "$sql" | sed 's/^[ \t]*//;s/[ \t]*$//')
-
     # Write the output to the specified file
     echo "$sql" > "$output_file"
 }


### PR DESCRIPTION
The change retains the indentation format for `manifest/ manifest list` db entries when doing an upgrade from postgres to sqlite. Without it, the manifest would be formatted changing it's content sha256 which results in incorrect sha being generated. 
Testing - manually verified that the change retains the original manifest json formatting 