### PR TITLE
chore: upgrade ansible ee to support ansible-core 2.16+

### DIFF
--- a/ansible-runner/context/Containerfile
+++ b/ansible-runner/context/Containerfile
@@ -1,5 +1,5 @@
-ARG EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-128
-ARG EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-22/ansible-builder-rhel8:1.1.0-32
+ARG EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:1.0.0-842
+ARG EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-25/ansible-builder-rhel8:3.1.0-225
 
 FROM $EE_BASE_IMAGE as galaxy
 ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=

--- a/ansible-runner/execution-environment.yml
+++ b/ansible-runner/execution-environment.yml
@@ -2,7 +2,7 @@
 version: 1
 
 build_arg_defaults:
-  EE_BASE_IMAGE: registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:1.0.0-128
+  EE_BASE_IMAGE: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:1.0.0-842
 
 dependencies:
   galaxy: requirements.yml


### PR DESCRIPTION
closes: https://github.com/quay/mirror-registry/issues/187
should close: #155 
On systems with Python 3.12+ and higher, for some reason (even with the EE encompassing its own version) the mirror-registry command fails at the last steps to wait for the host to be live, despite the actual service being up and usable.

This is caused to due to deprecations in parameters for Python3.12 + in the `urllib3` or `requests` libraries, causing the timeout to wait 3 minutes because of a parameter failure and them timeouts, causing workflows depending on the success/zero exit code to fail as well.

It is imperative that the base images are updated, as I have tried this across 20+ automated VM installs with many different versions of the library, it seems that this is the only fix (upgrading to Ansible 2.16+.)

I tested with `make build-online-zip` on a fresh server install.