### PR TITLE
chore: Retain quay container when quay fails to load (PROJQUAY-8607)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/wait-for-quay.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/wait-for-quay.yaml
@@ -10,16 +10,22 @@
       retries: 10
       delay: 30
   rescue:
-    - name: Print debug logs for quay-app in case of failure
-      command: systemctl --user status quay-app.service
+    - name: Print debug logs for quay-app container on failure
+      command: podman logs quay-app
+      register: quay_logs
+      ignore_errors: yes
+      changed_when: false
+
+    - name: Display logs if the container exists
+      when: quay_logs.rc == 0 and quay_logs.stdout != ""
+      debug:
+        msg: "{{ quay_logs.stdout_lines }}"
+
+    - name: Show quay-app.service status
+      command: systemctl --{{ systemd_scope }} status quay-app.service
       register: systemctl_status
       ignore_errors: yes
 
-    - name: Debug systemctl status output
-      debug:
-        var: systemctl_status.stdout_lines
-
-    - name: Fail the playbook due to Quay not becoming alive
+    - name:  Fail the playbook since Quay failed to startup
       fail:
-        msg: "Quay did not become alive. Check debug logs above for details."
-
+        msg: "Quay did not become alive, see systemctl status output: {{ systemctl_status.stdout_lines }}"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
@@ -26,7 +26,7 @@ ExecStart=/usr/bin/podman run \
     {{ quay_image }} {{ quay_cmd }}
     
 ExecStop=-/usr/bin/podman stop --ignore --cidfile %t/%n-cid -t 10
-ExecStopPost=-/usr/bin/podman rm --ignore -f --cidfile %t/%n-cid
+ExecStopPost=-/bin/sh -c 'if [ "$EXIT_STATUS" -eq 0  ]; then /usr/bin/podman rm --ignore -f --cidfile %t/%n-cid; fi'
 PIDFile=%t/%n-pid
 KillMode=none
 Restart=always


### PR DESCRIPTION
When `quay-app` container fails, it gets removed making it difficult to debug. This change keeps the container upon failure and uses it to fetch logs