### PR TITLE
bug: parallelize pg_dump to allow migration of large data sets to sqlite (PROJQUAY-8607)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
@@ -63,8 +63,28 @@
     dest: "{{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh"
     mode: '0755'
 
-- name: Convert PostgreSQL data-only dump to SQLite-compatible SQL file
-  command: /bin/bash "{{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh" "{{ expanded_quay_root }}/quay-postgres-backup/pg_data_dump.sql" "{{ expanded_quay_root }}/quay-postgres-backup/transformed_pgdata.sql"
+- name: Convert PostgreSQL data-only dump to SQLite-compatible SQL format
+  ansible.builtin.shell: |
+    {{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh "{{ input_file }}" "{{ output_file }}"
+  args:
+    executable: /bin/bash
+  register: conversion_result
+  failed_when: false
+  ignore_errors: yes
+  vars:
+    input_file: "{{ expanded_quay_root }}/quay-postgres-backup/pg_data_dump.sql"
+    output_file: "{{ expanded_quay_root }}/quay-postgres-backup/transformed_pgdata.sql"
+
+- name: Show detailed error if pg_to_sqlite.sh conversion failed
+  ansible.builtin.fail:
+    msg: |
+      Conversion failed with:
+      Exit code: {{ conversion_result.rc }}
+      Error output: {{ conversion_result.stderr | default(conversion_result.stdout) }}
+  failed_when:
+    - conversion_result.rc != 0
+    - not (output_file.stat.exists)
+    - output_file.stat.size == 0  # Output file empty
 
 - name: Stop Quay service
   systemd:

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
@@ -48,7 +48,6 @@
 - name: Run pg_dump in parallel to fetch postgres data as a .sql file
   command: /bin/bash "{{ expanded_quay_root }}/quay-postgres-backup/pg_dump.sh"
   register: pg_dump_output
-  changed_when: false
 
 - name: Copy the generated .sql file from postgres container to ansible host machine
   command: podman cp quay-postgres:/tmp/pg_data_dump.sql "{{ expanded_quay_root }}/quay-postgres-backup/"
@@ -65,26 +64,15 @@
 
 - name: Convert PostgreSQL data-only dump to SQLite-compatible SQL format
   ansible.builtin.shell: |
-    {{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh "{{ input_file }}" "{{ output_file }}"
+    {{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh "{{ input_file }}" "{{ output_file }}" 2>&1
   args:
     executable: /bin/bash
   register: conversion_result
-  failed_when: false
-  ignore_errors: yes
+  failed_when:
+    - conversion_result.rc != 0
   vars:
     input_file: "{{ expanded_quay_root }}/quay-postgres-backup/pg_data_dump.sql"
     output_file: "{{ expanded_quay_root }}/quay-postgres-backup/transformed_pgdata.sql"
-
-- name: Show detailed error if pg_to_sqlite.sh conversion failed
-  ansible.builtin.fail:
-    msg: |
-      Conversion failed with:
-      Exit code: {{ conversion_result.rc }}
-      Error output: {{ conversion_result.stderr | default(conversion_result.stdout) }}
-  failed_when:
-    - conversion_result.rc != 0
-    - not (output_file.stat.exists)
-    - output_file.stat.size == 0  # Output file empty
 
 - name: Stop Quay service
   systemd:

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
@@ -39,18 +39,32 @@
   ignore_errors: yes
   changed_when: remove_sqlite_cli.rc == 0
 
-- name: Take a pg_dump of the data from running quay-postgres container
-  command: >
-    podman exec -it quay-postgres
-    pg_dump --data-only --column-inserts --no-owner --no-privileges --disable-triggers
-    -U user -d quay
-  register: pg_dump_output
+- name: Copy pg_dump.sh bash script to host machine
+  template:
+    src: ../templates/pg_dump.sh
+    dest: "{{ expanded_quay_root }}/quay-postgres-backup/pg_dump.sh"
+    mode: '0755'
 
-- name: Back up postgres data to host machine
-  copy:
-    content: "{{ pg_dump_output.stdout }}"
-    dest: "{{ expanded_quay_root }}/quay-postgres-backup/pg_data_dump.sql"
-  when: pg_dump_output.stdout is defined
+- name: Run pg_dump in parallel to fetch postgres data as a .sql file
+  command: /bin/bash "{{ expanded_quay_root }}/quay-postgres-backup/pg_dump.sh"
+  register: pg_dump_output
+  changed_when: false
+
+- name: Copy the generated .sql file from postgres container to ansible host machine
+  command: podman cp quay-postgres:/tmp/pg_data_dump.sql "{{ expanded_quay_root }}/quay-postgres-backup/"
+
+- name: Display pg_dump output
+  debug:
+    var: pg_dump_output.stdout
+    
+- name: Copy postgres-to-sqlite bash script to host machine
+  template:
+    src: ../templates/pg_to_sqlite.sh
+    dest: "{{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh"
+    mode: '0755'
+
+- name: Convert PostgreSQL data-only dump to SQLite-compatible SQL file
+  command: /bin/bash "{{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh" "{{ expanded_quay_root }}/quay-postgres-backup/pg_data_dump.sql" "{{ expanded_quay_root }}/quay-postgres-backup/transformed_pgdata.sql"
 
 - name: Stop Quay service
   systemd:
@@ -61,7 +75,7 @@
     force: yes
     scope: "{{ systemd_scope }}"
 
-- name: Update DB_URI in config.yaml
+- name: Update DB_URI in config.yaml to sqlite file
   replace:
     path: "{{ expanded_quay_root }}/quay-config/config.yaml"
     regexp: '^DB_URI: postgresql://.*$'
@@ -105,7 +119,7 @@
     - "{{ sqlite_storage }}:/data:Z"
 
 - name: Copy data from container to host
-  command: podman cp quay-copy:/data {{ quay_root }}/quay-postgres-backup/
+  command: podman cp quay-copy:/data {{ expanded_quay_root }}/quay-postgres-backup/
 
 - name: Run sqlite3 command inside container to take quay's sqlite database schema dump
   command: >
@@ -145,15 +159,6 @@
     state: absent
     path: "{{ systemd_unit_dir }}/quay-migrate.service"
 
-- name: Copy postgres-to-sqlite bash script to host machine
-  template:
-    src: ../templates/pg_to_sqlite.sh
-    dest: "{{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh"
-    mode: '0755'
-
-- name: Convert PostgreSQL data-only dump to SQLite-compatible SQL file
-  command: /bin/bash "{{ expanded_quay_root }}/quay-postgres-backup/pg_to_sqlite.sh" "{{ expanded_quay_root }}/quay-postgres-backup/pg_data_dump.sql" "{{ expanded_quay_root }}/quay-postgres-backup/transformed_pgdata.sql"
-
 - name: Concatenate sqlite schema .sql and transformed postgres data into single merged_sqlite.sql
   shell: cat "{{ expanded_quay_root }}/quay-postgres-backup/sqlite_schema_dump.sql" "{{ expanded_quay_root }}/quay-postgres-backup/transformed_pgdata.sql" > "{{ expanded_quay_root }}/quay-postgres-backup/merged_sqlite.sql"
   args:
@@ -191,3 +196,4 @@
     daemon_reload: yes
     state: restarted
     scope: "{{ systemd_scope }}"
+

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/wait-for-quay.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/wait-for-quay.yaml
@@ -7,7 +7,7 @@
         validate_certs: no
       register: result
       until: result.status == 200
-      retries: 4
+      retries: 10
       delay: 30
   rescue:
     - name: Print debug logs for quay-app container on failure

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/wait-for-quay.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/wait-for-quay.yaml
@@ -7,7 +7,7 @@
         validate_certs: no
       register: result
       until: result.status == 200
-      retries: 10
+      retries: 4
       delay: 30
   rescue:
     - name: Print debug logs for quay-app container on failure

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_dump.sh
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_dump.sh
@@ -4,15 +4,15 @@ CPU_COUNT=$(nproc 2>/dev/null || echo 1)
 CPU_COUNT=$(( CPU_COUNT > 0 ? CPU_COUNT : 1))
 echo "CPU COUNT: ${CPU_COUNT}"
 
-# clean up postgres tmp/dumpdir if previously created
-podman exec quay-postgres rm -rf /tmp/dumpdir
+# clean up postgres tmp/pgdump_dir if previously created
+podman exec quay-postgres rm -rf /tmp/pgdump_dir
 
-# Take pg_dump of postgres container in parallel and store it in tmp/dumpdir
+# Take pg_dump of postgres container in parallel and store it in tmp/pgdump_dir
 podman exec -it quay-postgres \
     pg_dump -j "$CPU_COUNT" -Z 0 --no-sync --format=directory \
     --data-only --column-inserts --no-owner --no-privileges \
-    --disable-triggers -U user -d quay -f /tmp/dumpdir
+    --disable-triggers -U user -d quay -f /tmp/pgdump_dir
 
 # Convert the .dat dump files to a single .sql file using pg_restore
 podman exec -i quay-postgres \
-    pg_restore -Fd /tmp/dumpdir -f /tmp/pg_data_dump.sql -j "$CPU_COUNT"
+    pg_restore -Fd /tmp/pgdump_dir -f /tmp/pg_data_dump.sql -j "$CPU_COUNT"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_dump.sh
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_dump.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CPU_COUNT=$(nproc 2>/dev/null || echo 1)
+CPU_COUNT=$(( CPU_COUNT > 0 ? CPU_COUNT : 1))
+echo "CPU COUNT: ${CPU_COUNT}"
+
+# clean up postgres tmp/dumpdir if previously created
+podman exec quay-postgres rm -rf /tmp/dumpdir
+
+# Take pg_dump of postgres container in parallel and store it in tmp/dumpdir
+podman exec -it quay-postgres \
+    pg_dump -j "$CPU_COUNT" -Z 0 --no-sync --format=directory \
+    --data-only --column-inserts --no-owner --no-privileges \
+    --disable-triggers -U user -d quay -f /tmp/dumpdir
+
+# Convert the .dat dump files to a single .sql file using pg_restore
+podman exec -i quay-postgres \
+    pg_restore -Fd /tmp/dumpdir -f /tmp/pg_data_dump.sql -j "$CPU_COUNT"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_to_sqlite.sh
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_to_sqlite.sh
@@ -1,31 +1,50 @@
 #!/bin/bash
-set -euo pipefail  # Strict error handling
+set -euo pipefail
 
-# function that takes postgres data-only dump as "input_file" arg and converts it into a sqlite compatible .sql file
+# error tracing
+trap 'echo "ERROR at line $LINENO: Command failed - $BASH_COMMAND" >&2; exit 1' ERR
+
+#function that takes postgres data-only dump as "input_file" arg and converts it into a sqlite compatible .sql file
 pg_to_sqlite() {
     local input_file="$1"
     local output_file="$2"
 
-    [[ ! -s "$input_file" ]] && { echo "Error: Input file is empty!" >&2; exit 1; }
+    # Validate input file
+    [[ ! -f "$input_file" ]] && { echo "Error: Input file '$input_file' not found (line $LINENO)" >&2; exit 1; }
+    [[ ! -s "$input_file" ]] && { echo "Error: Input file '$input_file' is empty (line $LINENO)" >&2; exit 1; }
 
-    # Process with sed
-    sed -E "
-        s/'true'/1/g;
-        s/'false'/0/g;
-        /SET\s+\w+\s*=\s*[^;]+;/d;
-        /^\s*--.*$/d;
-        /ALTER TABLE .*? DISABLE TRIGGER ALL;/d;
-        /ALTER TABLE .*? ENABLE TRIGGER ALL;/d;
-        s/SELECT pg_catalog\.set_config\('search_path', '', false\);//g;
-        /SET SESSION AUTHORIZATION DEFAULT;/d;
-        /SET client_encoding = '\''UTF8'\'';/d;
-        /^pg_dump:.*$/d;
-        s/SELECT pg_catalog\.setval\('public\..*?', [0-9]+, (true|false)\);//g;
-        s/INSERT INTO public\./INSERT INTO /g;
-        /^\s*$/d;
-    " "$input_file" > "$output_file"
+    {
+        echo "BEGIN TRANSACTION;"
 
-    [[ ! -s "$output_file" ]] && { echo "Error: Output file is empty!" >&2; exit 1; }
+        # Process conversion
+        sed -E "
+            s/'true'/1/g;
+            s/'false'/0/g;
+            /SET\s+\w+\s*=\s*[^;]+;/d;
+            /^\s*--.*$/d;
+            /ALTER TABLE .*? DISABLE TRIGGER ALL;/d;
+            /ALTER TABLE .*? ENABLE TRIGGER ALL;/d;
+            s/SELECT pg_catalog\.set_config\('search_path', '', false\);//g;
+            /SET SESSION AUTHORIZATION DEFAULT;/d;
+            /SET client_encoding = '\''UTF8'\'';/d;
+            /^pg_dump:.*$/d;
+            s/SELECT pg_catalog\.setval\('public\..*?', [0-9]+, (true|false)\);//g;
+            s/INSERT INTO public\./INSERT INTO /g;
+            /^\s*$/d;
+        " "$input_file"
+
+        echo "COMMIT;"
+    } > "$output_file"
+
+    # Validate output file
+    if [[ ! -f "$output_file" ]]; then
+        echo "Error: Output file '$output_file' was not created (line $LINENO)" >&2
+        exit 1
+    elif [[ ! -s "$output_file" ]]; then
+        echo "Error: Output file '$output_file' is empty (line $LINENO)" >&2
+        exit 1
+    fi
 }
 
 pg_to_sqlite "$1" "$2"
+echo "Success: Created valid output file '$2'"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_to_sqlite.sh
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/pg_to_sqlite.sh
@@ -1,50 +1,31 @@
 #!/bin/bash
+set -euo pipefail  # Strict error handling
 
-# Function that takes postgres data-only dump as "input_file" arg and converts it into a sqlite compatible .sql file
+# function that takes postgres data-only dump as "input_file" arg and converts it into a sqlite compatible .sql file
 pg_to_sqlite() {
     local input_file="$1"
     local output_file="$2"
 
-    # Read the input file
-    sql=$(<"$input_file")
+    [[ ! -s "$input_file" ]] && { echo "Error: Input file is empty!" >&2; exit 1; }
 
-    # Replace PostgreSQL-specific data types with SQLite equivalents
-    sql=$(echo "$sql" | sed "s/'true'/1/g")
-    sql=$(echo "$sql" | sed "s/'false'/0/g")
+    # Process with sed
+    sed -E "
+        s/'true'/1/g;
+        s/'false'/0/g;
+        /SET\s+\w+\s*=\s*[^;]+;/d;
+        /^\s*--.*$/d;
+        /ALTER TABLE .*? DISABLE TRIGGER ALL;/d;
+        /ALTER TABLE .*? ENABLE TRIGGER ALL;/d;
+        s/SELECT pg_catalog\.set_config\('search_path', '', false\);//g;
+        /SET SESSION AUTHORIZATION DEFAULT;/d;
+        /SET client_encoding = '\''UTF8'\'';/d;
+        /^pg_dump:.*$/d;
+        s/SELECT pg_catalog\.setval\('public\..*?', [0-9]+, (true|false)\);//g;
+        s/INSERT INTO public\./INSERT INTO /g;
+        /^\s*$/d;
+    " "$input_file" > "$output_file"
 
-    # Remove PostgreSQL-specific commands not supported by SQLite
-    sql=$(echo "$sql" | sed -E '/SET\s+\w+\s*=\s*[^;]+;/d')
-    sql=$(echo "$sql" | sed -E '/^\s*--.*$/d')
-    sql=$(echo "$sql" | sed -E '/ALTER TABLE .*? DISABLE TRIGGER ALL;/d')
-    sql=$(echo "$sql" | sed -E '/ALTER TABLE .*? ENABLE TRIGGER ALL;/d')
-    sql=$(echo "$sql" | sed -E "s/SELECT pg_catalog\.set_config\('search_path', '', false\);//g")
-    sql=$(echo "$sql" | sed -E '/SET SESSION AUTHORIZATION DEFAULT;/d')
-    sql=$(echo "$sql" | sed -E '/SET client_encoding = '\''UTF8'\'';/d')
-
-    # Remove lines starting with "pg_dump:"
-    sql=$(echo "$sql" | sed -E '/^pg_dump:.*$/d')
-
-    # Remove original PostgreSQL sequence set statements
-    sql=$(echo "$sql" | sed -E "s/SELECT pg_catalog\.setval\('public\..*?', [0-9]+, (true|false)\);//g")
-
-    # Remove the `public.` schema prefix from table names
-    sql=$(echo "$sql" | sed "s/INSERT INTO public\./INSERT INTO /g")
-
-    # Remove empty lines
-    sql=$(echo "$sql" | sed "/^\s*$/d")
-
-    # Write the output to the specified file
-    echo "$sql" > "$output_file"
+    [[ ! -s "$output_file" ]] && { echo "Error: Output file is empty!" >&2; exit 1; }
 }
 
-# Check if the script receives two arguments
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <input_file> <output_file>"
-    exit 1
-fi
-
-input_file="$1"
-output_file="$2"
-
-# Call the function
-pg_to_sqlite "$input_file" "$output_file"
+pg_to_sqlite "$1" "$2"


### PR DESCRIPTION
**Changes**:
1. Stores `pg_dump` output in a directory path inside postgres container avoiding ansible container needing to parse the `pg_dump` output which is CPU intensive.

2. Adds additional flag `-j` to parallelize `pg_dump` to utilize CPU cores when available. 
      Note:  `-j` flag only support directory output format, hence i use `pg_restore` to create the `.sql` file. 
      
3. Modifies the previous `pg_to_sqlite.sh` script that converts the postgres `.sql` file to a SQlite compatible file. The earlier version errors out with `xrealloc` memory overflow for large data set since it was being stored in a single variable

4. Adds `BEGIN` and `COMMIT` to wrap all insert sql statements into a single transaction for faster import into SQlite

**Testing**:
Tested postgres to sqlite upgrade path against 1GB db (10 mil rows) and the upgrade took less than 5min. Compared to previous version which never finished even after 15min