### PR TITLE
Fix order loginctl enable-linger

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/main.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/main.yaml
@@ -7,6 +7,10 @@
 - name: Install Dependencies
   include_tasks: install-deps.yaml
 
+- name: Enable lingering for systemd user processes
+  command: "loginctl enable-linger"
+  when: ansible_user_uid != 0
+
 - name: Set SELinux Rules
   include_tasks: set-selinux-rules.yaml
 
@@ -27,7 +31,3 @@
 
 - name: Create init user
   include_tasks: create-init-user.yaml
-
-- name: Enable lingering for systemd user processes
-  command: "loginctl enable-linger"
-  when: ansible_user_uid != 0


### PR DESCRIPTION
Podman 5.1.0 introduced the following feature:

```
Podman now detects unhandled system reboots and advises the user on proper mitigations.
```
https://github.com/containers/podman/releases?q=v5.1.0&expanded=true

This seems to cause the following error (aftre a reboot) if linger is not enabled before installation:

```
Error: current system boot ID differs from cached boot ID; an unhandled reboot has occurred. Please delete directories "/tmp/storage-run-1001/containers" and "/tmp/storage-run-1001/libpod/tmp" and re-run Podman
```

The enable linger setting should be set BEFORE the containers are started otherwise the quay is not started after a reboot.

tested with:
RHEL Version: RHEL 9.6
Podman Version: 5.4.0