### PR TITLE
Multi-arch Build Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,21 @@ ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
-# Get Go binary
-RUN curl -o go1.25.5.linux-amd64.tar.gz https://dl.google.com/go/go1.25.5.linux-amd64.tar.gz
-RUN tar -xzf go1.25.5.linux-amd64.tar.gz  &&\
+# Get Go binary (detect architecture)
+RUN if [ -n "${TARGETARCH}" ]; then \
+        # respect --platform build flag
+        GOARCH="${TARGETARCH}"; \
+    else \
+        ARCH=$(uname -m); \
+        if [ "$ARCH" = "x86_64" ]; then GOARCH="amd64"; \
+        elif [ "$ARCH" = "aarch64" ]; then GOARCH="arm64"; \
+        elif [ "$ARCH" = "ppc64le" ]; then GOARCH="ppc64le"; \
+        elif [ "$ARCH" = "s390x" ]; then GOARCH="s390x"; \
+        else echo "Unsupported architecture: $ARCH" && exit 1; fi; \
+    fi && \
+    curl -o go1.25.5.linux-${GOARCH}.tar.gz \
+        https://dl.google.com/go/go1.25.5.linux-${GOARCH}.tar.gz && \
+    tar -xzf go1.25.5.linux-${GOARCH}.tar.gz && \
     mv go /usr/local
 
 COPY . /cli

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -16,9 +16,21 @@ ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
-# Get Go binary
-RUN curl -o go1.25.5.linux-amd64.tar.gz https://dl.google.com/go/go1.25.5.linux-amd64.tar.gz
-RUN tar -xzf go1.25.5.linux-amd64.tar.gz  &&\
+# Get Go binary (detect architecture)
+RUN if [ -n "${TARGETARCH}" ]; then \
+        # respect --platform build flag
+        GOARCH="${TARGETARCH}"; \
+    else \
+        ARCH=$(uname -m); \
+        if [ "$ARCH" = "x86_64" ]; then GOARCH="amd64"; \
+        elif [ "$ARCH" = "aarch64" ]; then GOARCH="arm64"; \
+        elif [ "$ARCH" = "ppc64le" ]; then GOARCH="ppc64le"; \
+        elif [ "$ARCH" = "s390x" ]; then GOARCH="s390x"; \
+        else echo "Unsupported architecture: $ARCH" && exit 1; fi; \
+    fi && \
+    curl -o go1.25.5.linux-${GOARCH}.tar.gz \
+        https://dl.google.com/go/go1.25.5.linux-${GOARCH}.tar.gz && \
+    tar -xzf go1.25.5.linux-${GOARCH}.tar.gz && \
     mv go /usr/local
 
 COPY . /cli


### PR DESCRIPTION
I noticed when running the offline zip build on a remote ppc64le host with podman's CONTAINER_HOST env variable, the build would fail due to grabbing the wrong arch for the golang binary. This change allows builds to be conducted on different architectures. 