### PR TITLE
[mirror-registry-2.0-rhel-8] deps: Bump go-version to 1.25.7 (PROJQUAY-10465)

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.5
+          go-version: 1.25.7
         id: go
 
       - name: Get dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG REDIS_IMAGE=${REDIS_IMAGE}
 ARG PAUSE_IMAGE=${PAUSE_IMAGE}
 ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.5 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.5-1769026830 AS cli
+# Create Go CLI using Red Hat Go 1.25.7 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -2,8 +2,8 @@ ARG RELEASE_VERSION=${RELEASE_VERSION}
 ARG EE_BASE_IMAGE=${EE_BASE_IMAGE}
 ARG EE_BUILDER_IMAGE=${EE_BUILDER_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.5 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.5-1769026830 AS cli
+# Create Go CLI using Red Hat Go 1.25.7 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.5 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.7 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/lib/pq v1.10.0


### PR DESCRIPTION
Dockerfile	
Updated ubi8/go-toolset image tag from 1.25.5-1769026830 to 1.25.7 and comment

Dockerfile.online	
Updated ubi8/go-toolset image tag from 1.25.5-1769026830 to 1.25.7 and comment

go.mod	
Updated go directive from 1.25.5 to 1.25.7

Makefile	
Updated docker.io/golang image tag from 1.25.5 to 1.25.7

.github/workflows/jobs.yml	
Updated go-version from 1.25.5 to 1.25.7