### PR TITLE
PROJQUAY-10963: deps: Bump go-version to 1.25.8 for main [master]

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
 
       - name: Build
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
 # Get Go binary
-RUN curl -o go1.25.7.linux-amd64.tar.gz https://dl.google.com/go/go1.25.7.linux-amd64.tar.gz
-RUN tar -xzf go1.25.7.linux-amd64.tar.gz  &&\
+RUN curl -o go1.25.8.linux-amd64.tar.gz https://dl.google.com/go/go1.25.8.linux-amd64.tar.gz
+RUN tar -xzf go1.25.8.linux-amd64.tar.gz  &&\
     mv go /usr/local
 
 COPY . /cli

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -17,8 +17,8 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
 # Get Go binary
-RUN curl -o go1.25.7.linux-amd64.tar.gz https://dl.google.com/go/go1.25.7.linux-amd64.tar.gz
-RUN tar -xzf go1.25.7.linux-amd64.tar.gz  &&\
+RUN curl -o go1.25.8.linux-amd64.tar.gz https://dl.google.com/go/go1.25.8.linux-amd64.tar.gz
+RUN tar -xzf go1.25.8.linux-amd64.tar.gz  &&\
     mv go /usr/local
 
 COPY . /cli

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.7 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.8 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/lib/pq v1.10.0


### PR DESCRIPTION
Next changes performed

File	                                                                            
--->.github/workflows/pr-check.yml                          
go-version: 1.25.7 -> 1.25.8

--->Dockerfile
Go tarball download go1.25.7 -> go1.25.8

--->Dockerfile.online
Go tarball download go1.25.7 -> go1.25.8

--->Makefile
docker.io/golang:1.25.7 -> 1.25.8

--->go.mod
go 1.25.7 -> go 1.25.8

Made-with: Cursor