### PR TITLE
[mirror-registry-2.0-rhel-8] deps: Bump go-version to 1.25.8 (PROJQUAY-10963)

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
         id: go
 
       - name: Get dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.5
+          go-version: 1.25.8
 
       - name: Build
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG REDIS_IMAGE=${REDIS_IMAGE}
 ARG PAUSE_IMAGE=${PAUSE_IMAGE}
 ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.7 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 AS cli
+# Create Go CLI using Red Hat Go 1.25.8 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -2,8 +2,8 @@ ARG RELEASE_VERSION=${RELEASE_VERSION}
 ARG EE_BASE_IMAGE=${EE_BASE_IMAGE}
 ARG EE_BUILDER_IMAGE=${EE_BUILDER_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.7 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.7 AS cli
+# Create Go CLI using Red Hat Go 1.25.8 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.7 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.8 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/lib/pq v1.10.0


### PR DESCRIPTION
Next changes performed

--->.github/workflows/jobs.yml
go-version: 1.25.7 -> 1.25.8

--->.github/workflows/pr-check.yml
go-version: 1.25.5 -> 1.25.8 (was missed in previous bump)

--->Dockerfile
ubi8/go-toolset:1.25.7 -> 1.25.8 + comment update

--->Dockerfile.online
ubi8/go-toolset:1.25.7 -> 1.25.8 + comment update

--->Makefile
docker.io/golang:1.25.7 -> 1.25.8

--->go.mod
go 1.25.7 -> go 1.25.8

Made-with: Cursor