### PR TITLE
fix: add U flag to sqlite volume mount for podman 5.x compatibility (PROJQUAY-9329)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/templates/quay.service.j2
@@ -12,7 +12,7 @@ ExecStartPre=-/bin/rm -f %t/%n-pid %t/%n-cid
 ExecStart=/usr/bin/podman run \
     --name quay-app \
     -v {{ expanded_quay_root }}/quay-config:/quay-registry/conf/stack:Z \
-    -v {{ expanded_sqlite_storage }}:/sqlite:Z \
+    -v {{ expanded_sqlite_storage }}:/sqlite:Z,U \
     -v {{ expanded_quay_storage }}:/datastorage:Z \
     --image-volume=ignore \
     --pod=quay-pod \


### PR DESCRIPTION
 Summary

  - Adds the :U volume mount flag to the sqlite volume in quay.service.j2, which tells podman to recursively chown the volume to match the container's runtime user
  - Fixes upgrade failures (1.3.x → 2.x) on podman 5.x where the sqlite-storage volume ownership resets to root:root after the quay-copy container is removed, causing
  peewee.OperationalError: attempt to write a readonly database
  - Complements the existing fix in PR #243 (which addressed the migration path only via hardcoded podman unshare chown to UID 1001) by handling the upgrade path and supporting containers
   running as any UID

  Notes

  - The :U flag is only applied to the sqlite volume, not quay-storage, as recursive chown on a volume with many blobs could delay startup or hit the 3-minute health check timeout
  - Issue does not reproduce on podman 4.9.x, only on podman 5.x