### PR TITLE
NO-ISSUE: ci(ci): add Codecov coverage reporting

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -29,3 +29,11 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+      - name: Test
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -37,3 +37,5 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- Adds `go test -coverprofile=coverage.out -covermode=atomic ./...` to the PR Check workflow
- Uploads coverage reports to Codecov using `codecov/codecov-action@v6.0.0`

## Test plan
- [ ] Verify the `go-validate` job passes in CI
- [ ] Verify coverage is uploaded to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)