### PR TITLE
feat: add Codecov integration for unit test coverage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,6 +1,9 @@
 name: "PR Check"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -8,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   go-validate:
@@ -31,4 +35,12 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./... -v
+        run: go test ./... -v -coverprofile=coverage.out -covermode=atomic
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.out
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "20...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "vendor/**"
+  - "test/**"
+  - "agent_docs/**"
+  - "ansible-runner/**"
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default


### PR DESCRIPTION
## Summary
- Add coverage profiling (`-coverprofile`) and Codecov upload to the PR check workflow
- Use OIDC authentication (no token/secret needed for public repos on app.codecov.io)
- Add `push` trigger on `main` to establish baseline coverage for PR diff comparisons
- Add `codecov.yml` with ignore patterns, `unit-tests` flag, and PR comment configuration

## Test plan
- [ ] Verify PR check workflow runs `go test` with coverage and uploads to Codecov
- [ ] After merging, verify push to `main` uploads baseline coverage
- [ ] Check https://app.codecov.io for `quay/mirror-registry` coverage data
- [ ] Enable flag analytics in Codecov UI → Flags tab → "Enable flag analytics"
- [ ] Verify subsequent PRs show coverage diff in Codecov PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)