### PR TITLE
PROJQUAY-11290: deps: Bump go-version to 1.25.9 for main [master]

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
 
       - name: Build
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
 # Get Go binary
-RUN curl -o go1.25.9.linux-amd64.tar.gz https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz
-RUN tar -xzf go1.25.9.linux-amd64.tar.gz  &&\
+RUN curl -o go1.25.10.linux-amd64.tar.gz https://dl.google.com/go/go1.25.10.linux-amd64.tar.gz
+RUN tar -xzf go1.25.10.linux-amd64.tar.gz  &&\
     mv go /usr/local
 
 COPY . /cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
 # Get Go binary
-RUN curl -o go1.25.8.linux-amd64.tar.gz https://dl.google.com/go/go1.25.8.linux-amd64.tar.gz
-RUN tar -xzf go1.25.8.linux-amd64.tar.gz  &&\
+RUN curl -o go1.25.9.linux-amd64.tar.gz https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz
+RUN tar -xzf go1.25.9.linux-amd64.tar.gz  &&\
     mv go /usr/local
 
 COPY . /cli

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -17,8 +17,8 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
 # Get Go binary
-RUN curl -o go1.25.9.linux-amd64.tar.gz https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz
-RUN tar -xzf go1.25.9.linux-amd64.tar.gz  &&\
+RUN curl -o go1.25.10.linux-amd64.tar.gz https://dl.google.com/go/go1.25.10.linux-amd64.tar.gz
+RUN tar -xzf go1.25.10.linux-amd64.tar.gz  &&\
     mv go /usr/local
 
 COPY . /cli

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -17,8 +17,8 @@ ENV GOROOT=/usr/local/go
 ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
 
 # Get Go binary
-RUN curl -o go1.25.8.linux-amd64.tar.gz https://dl.google.com/go/go1.25.8.linux-amd64.tar.gz
-RUN tar -xzf go1.25.8.linux-amd64.tar.gz  &&\
+RUN curl -o go1.25.9.linux-amd64.tar.gz https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz
+RUN tar -xzf go1.25.9.linux-amd64.tar.gz  &&\
     mv go /usr/local
 
 COPY . /cli

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.9 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.10 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.8 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.9 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/lib/pq v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/lib/pq v1.10.0


### PR DESCRIPTION
Changes

Dockerfile
Updated Go tarball download and extraction from go1.25.8 to go1.25.9

Dockerfile.online
Updated Go tarball download and extraction from go1.25.8 to go1.25.9

go.mod
Updated go directive from 1.25.8 to 1.25.9

Makefile
Updated docker.io/golang image tag from 1.25.8 to 1.25.9

.github/workflows/pr-check.yml
Updated go-version from 1.25.8 to 1.25.9

This resolves [PROJQUAY-11290](https://redhat.atlassian.net/browse/PROJQUAY-11290)