### PR TITLE
[mirror-registry-2.0-rhel-8] deps: Bump go-version to 1.25.9 (PROJQUAY-11290)

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.10
+          go-version: 1.25.9
         id: go
 
       - name: Get dependencies

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
         id: go
 
       - name: Get dependencies

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
         id: go
 
       - name: Get dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.8
+          go-version: 1.25.9
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.10
+          go-version: 1.25.9
 
       - name: Build
         run: go build -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG REDIS_IMAGE=${REDIS_IMAGE}
 ARG PAUSE_IMAGE=${PAUSE_IMAGE}
 ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.9 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9 AS cli
+# Create Go CLI using Red Hat Go 1.25.10 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.10 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG REDIS_IMAGE=${REDIS_IMAGE}
 ARG PAUSE_IMAGE=${PAUSE_IMAGE}
 ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.10 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.10 AS cli
+# Create Go CLI using Red Hat Go 1.25.9 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ARG REDIS_IMAGE=${REDIS_IMAGE}
 ARG PAUSE_IMAGE=${PAUSE_IMAGE}
 ARG SQLITE_IMAGE=${SQLITE_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.8 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8 AS cli
+# Create Go CLI using Red Hat Go 1.25.9 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -2,8 +2,8 @@ ARG RELEASE_VERSION=${RELEASE_VERSION}
 ARG EE_BASE_IMAGE=${EE_BASE_IMAGE}
 ARG EE_BUILDER_IMAGE=${EE_BUILDER_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.10 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.10 AS cli
+# Create Go CLI using Red Hat Go 1.25.9 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -2,8 +2,8 @@ ARG RELEASE_VERSION=${RELEASE_VERSION}
 ARG EE_BASE_IMAGE=${EE_BASE_IMAGE}
 ARG EE_BUILDER_IMAGE=${EE_BUILDER_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.9 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9 AS cli
+# Create Go CLI using Red Hat Go 1.25.10 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.10 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Dockerfile.online
+++ b/Dockerfile.online
@@ -2,8 +2,8 @@ ARG RELEASE_VERSION=${RELEASE_VERSION}
 ARG EE_BASE_IMAGE=${EE_BASE_IMAGE}
 ARG EE_BUILDER_IMAGE=${EE_BUILDER_IMAGE}
 
-# Create Go CLI using Red Hat Go 1.25.8 Toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.25.8 AS cli
+# Create Go CLI using Red Hat Go 1.25.9 Toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.25.9 AS cli
 
 # Need to duplicate these, otherwise they won't be available to the stage
 ARG RELEASE_VERSION=${RELEASE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.9 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.10 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.8 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.9 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RELEASE_VERSION ?= dev
 all:
 
 build-golang-executable:
-	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.10 go build -v \
+	$(CLIENT) run --rm -v ${PWD}:/usr/src:Z -w /usr/src docker.io/golang:1.25.9 go build -v \
 	-ldflags "-X 'github.com/quay/mirror-registry/cmd.releaseVersion=${RELEASE_VERSION}' -X 'github.com/quay/mirror-registry/cmd.eeImage=${EE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.pauseImage=${PAUSE_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.quayImage=${QUAY_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.redisImage=${REDIS_IMAGE}' -X 'github.com/quay/mirror-registry/cmd.sqliteImage=${SQLITE_IMAGE}'" \
 	-o mirror-registry;
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/lib/pq v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.10
+go 1.25.9
 
 require (
 	github.com/lib/pq v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/mirror-registry
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/lib/pq v1.10.0


### PR DESCRIPTION
Dockerfile
Updated Red Hat Go Toolset image tag and comment from 1.25.8 to 1.25.9

Dockerfile.online
Updated Red Hat Go Toolset image tag and comment from 1.25.8 to 1.25.9

go.mod
Updated go directive from 1.25.8 to 1.25.9

Makefile
Updated docker.io/golang image tag from 1.25.8 to 1.25.9

.github/workflows/jobs.yml
Updated go-version from 1.25.8 to 1.25.9

.github/workflows/pr-check.yml
Updated go-version from 1.25.8 to 1.25.9

This resolves [PROJQUAY-11290](https://redhat.atlassian.net/browse/PROJQUAY-11290)