### PR TITLE
test: cherry-pick e2e test coverage and Codecov to mirror-registry-2.0-rhel-8

### DIFF
--- a/.github/workflows/extended-errors-installer/main.tf
+++ b/.github/workflows/extended-errors-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_errors" {
+  name = "terraform-network-extended-errors"
+}
+
+resource "google_compute_instance" "vm_instance_extended_errors" {
+  name         = "mirror-ci-rhel-extended-errors"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-errors"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_errors.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-errors" {
+  name    = "vm-ssh-extended-errors"
+  network = google_compute_network.vpc_network_extended_errors.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-errors"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_errors.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-health-installer/main.tf
+++ b/.github/workflows/extended-health-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_health" {
+  name = "terraform-network-extended-health"
+}
+
+resource "google_compute_instance" "vm_instance_extended_health" {
+  name         = "mirror-ci-rhel-extended-health"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-health"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_health.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-health" {
+  name    = "vm-ssh-extended-health"
+  network = google_compute_network.vpc_network_extended_health.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-health"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_health.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-hostname-installer/main.tf
+++ b/.github/workflows/extended-hostname-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_hostname" {
+  name = "terraform-network-extended-hostname"
+}
+
+resource "google_compute_instance" "vm_instance_extended_hostname" {
+  name         = "mirror-ci-rhel-extended-hostname"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-hostname"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_hostname.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-hostname" {
+  name    = "vm-ssh-extended-hostname"
+  network = google_compute_network.vpc_network_extended_hostname.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-hostname"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_hostname.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-paths-installer/main.tf
+++ b/.github/workflows/extended-paths-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_paths" {
+  name = "terraform-network-extended-paths"
+}
+
+resource "google_compute_instance" "vm_instance_extended_paths" {
+  name         = "mirror-ci-rhel-extended-paths"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-paths"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_paths.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-paths" {
+  name    = "vm-ssh-extended-paths"
+  network = google_compute_network.vpc_network_extended_paths.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-paths"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_paths.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-port-installer/main.tf
+++ b/.github/workflows/extended-port-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_port" {
+  name = "terraform-network-extended-port"
+}
+
+resource "google_compute_instance" "vm_instance_extended_port" {
+  name         = "mirror-ci-rhel-extended-port"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-port"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_port.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-port" {
+  name    = "vm-ssh-extended-port"
+  network = google_compute_network.vpc_network_extended_port.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-port"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_port.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-reinstall-installer/main.tf
+++ b/.github/workflows/extended-reinstall-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_reinstall" {
+  name = "terraform-network-extended-reinstall"
+}
+
+resource "google_compute_instance" "vm_instance_extended_reinstall" {
+  name         = "mirror-ci-rhel-extended-reinstall"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-reinstall"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_reinstall.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-reinstall" {
+  name    = "vm-ssh-extended-reinstall"
+  network = google_compute_network.vpc_network_extended_reinstall.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-reinstall"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_reinstall.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-root-installer/main.tf
+++ b/.github/workflows/extended-root-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_root" {
+  name = "terraform-network-extended-root"
+}
+
+resource "google_compute_instance" "vm_instance_extended_root" {
+  name         = "mirror-ci-rhel-extended-root"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-root"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_root.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-root" {
+  name    = "vm-ssh-extended-root"
+  network = google_compute_network.vpc_network_extended_root.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-root"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_root.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -289,3 +289,385 @@ jobs:
         shell: bash
         working-directory: ".github/workflows/extended-uninstall-installer"
         if: always()
+
+  test-custom-paths:
+    name: "Custom Storage Paths"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-paths-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run custom paths test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-custom-paths.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-paths-installer"
+        if: always()
+
+  test-custom-hostname:
+    name: "Custom Hostname"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-hostname-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run custom hostname test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-custom-hostname.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-hostname-installer"
+        if: always()
+
+  test-sqlite-upgrade:
+    name: "SQLite-to-SQLite Upgrade"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-upgrade-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run SQLite-to-SQLite upgrade test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-upgrade-sqlite.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-upgrade-installer"
+        if: always()
+
+  test-idempotent-reinstall:
+    name: "Idempotent Reinstall"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-reinstall-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run idempotent reinstall test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-idempotent-reinstall.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-reinstall-installer"
+        if: always()
+
+  test-tls-mismatch:
+    name: "TLS Hostname Mismatch"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-tls-mismatch-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Run TLS mismatch test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-tls-mismatch.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-tls-mismatch-installer"
+        if: always()

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -671,3 +671,234 @@ jobs:
         shell: bash
         working-directory: ".github/workflows/extended-tls-mismatch-installer"
         if: always()
+
+  test-error-paths:
+    name: "Error Handling"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-errors-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Run invalid cert error test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-error-invalid-cert.sh ~'
+
+      - name: Run missing podman error test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-error-no-podman.sh ~'
+
+      - name: Run auto-generated password test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-auto-password.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-errors-installer"
+        if: always()
+
+  test-nonstandard-port:
+    name: "Non-Standard Port"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-port-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run non-standard port test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-nonstandard-port.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-port-installer"
+        if: always()
+
+  test-health-endpoint:
+    name: "Health Endpoint Validation"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-health-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Run health endpoint test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-health-endpoint.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-health-installer"
+        if: always()

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -1,0 +1,291 @@
+name: "Extended Tests"
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - main
+      - mirror-registry-*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: extended-tests
+
+jobs:
+  build-installer:
+    name: "Build Offline Installer"
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set version
+        run: echo "RELEASE_VERSION=$GITHUB_REF_NAME" >>"$GITHUB_ENV"
+
+      - name: Log into registry.redhat.io
+        uses: docker/login-action@v2
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build offline tarfile
+        run: |
+          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
+
+          docker build \
+            -t "mirror-registry-offline:ci" \
+            --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
+            --build-arg "QUAY_IMAGE=$(get_env QUAY_IMAGE)" \
+            --build-arg "EE_IMAGE=$(get_env EE_IMAGE)" \
+            --build-arg "EE_BASE_IMAGE=$(get_env EE_BASE_IMAGE)" \
+            --build-arg "EE_BUILDER_IMAGE=$(get_env EE_BUILDER_IMAGE)" \
+            --build-arg "REDIS_IMAGE=$(get_env REDIS_IMAGE)" \
+            --build-arg "PAUSE_IMAGE=$(get_env PAUSE_IMAGE)" \
+            --build-arg "SQLITE_IMAGE=$(get_env SQLITE_IMAGE)" \
+            --file Dockerfile .
+
+          docker run --name mirror-registry-offline-ci "mirror-registry-offline:ci"
+          docker cp mirror-registry-offline-ci:/mirror-registry.tar.gz .
+          docker rm mirror-registry-offline-ci
+
+      - name: Upload tarfile
+        uses: actions/upload-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+          path: mirror-registry.tar.gz
+          retention-days: 1
+
+  test-custom-tls:
+    name: "Custom TLS Certificate"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-tls-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Run custom TLS test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-custom-tls.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-tls-installer"
+        if: always()
+
+  test-root-install:
+    name: "Root Install"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-root-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run root install test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-root-install.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-root-installer"
+        if: always()
+
+  test-uninstall-verification:
+    name: "Uninstall Verification"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-uninstall-installer"
+
+      - name: Wait for VM
+        uses: jakejarvis/wait-action@master
+        with:
+          time: "60s"
+
+      - name: Download tarfile
+        uses: actions/download-artifact@v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball and test scripts to VM
+        run: |
+          scp mirror-registry.tar.gz ci-user@quay:~/
+          scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run uninstall verification test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-uninstall-verification.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-uninstall-installer"
+        if: always()

--- a/.github/workflows/extended-tls-installer/main.tf
+++ b/.github/workflows/extended-tls-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_tls" {
+  name = "terraform-network-extended-tls"
+}
+
+resource "google_compute_instance" "vm_instance_extended_tls" {
+  name         = "mirror-ci-rhel-extended-tls"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-tls"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_tls.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-tls" {
+  name    = "vm-ssh-extended-tls"
+  network = google_compute_network.vpc_network_extended_tls.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-tls"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_tls.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-tls-mismatch-installer/main.tf
+++ b/.github/workflows/extended-tls-mismatch-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_tls_mismatch" {
+  name = "terraform-network-extended-tls-mismatch"
+}
+
+resource "google_compute_instance" "vm_instance_extended_tls_mismatch" {
+  name         = "mirror-ci-rhel-extended-tls-mismatch"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-tls-mismatch"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_tls_mismatch.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-tls-mismatch" {
+  name    = "vm-ssh-extended-tls-mismatch"
+  network = google_compute_network.vpc_network_extended_tls_mismatch.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-tls-mismatch"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_tls_mismatch.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-uninstall-installer/main.tf
+++ b/.github/workflows/extended-uninstall-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_uninstall" {
+  name = "terraform-network-extended-uninstall"
+}
+
+resource "google_compute_instance" "vm_instance_extended_uninstall" {
+  name         = "mirror-ci-rhel-extended-uninstall"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-uninstall"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_uninstall.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-uninstall" {
+  name    = "vm-ssh-extended-uninstall"
+  network = google_compute_network.vpc_network_extended_uninstall.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-uninstall"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_uninstall.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/extended-upgrade-installer/main.tf
+++ b/.github/workflows/extended-upgrade-installer/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.18.1"
+    }
+  }
+}
+
+
+variable "SSH_PUBLIC_KEY" {
+  type = string
+}
+
+provider "google" {
+
+  project = "quay-devel"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+
+}
+
+resource "google_compute_network" "vpc_network_extended_upgrade" {
+  name = "terraform-network-extended-upgrade"
+}
+
+resource "google_compute_instance" "vm_instance_extended_upgrade" {
+  name         = "mirror-ci-rhel-extended-upgrade"
+  machine_type = "e2-standard-4"
+
+  boot_disk {
+    initialize_params {
+      image = "rhel-9"
+      size  = 100
+    }
+  }
+
+  tags = ["mirror-ci-rhel-extended-upgrade"]
+
+  network_interface {
+    network = google_compute_network.vpc_network_extended_upgrade.name
+    access_config {
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ci-user:${var.SSH_PUBLIC_KEY}"
+  }
+
+  service_account {
+    scopes = []
+  }
+
+  scheduling {
+    max_run_duration {
+      seconds = 7200
+    }
+    instance_termination_action = "DELETE"
+  }
+}
+
+resource "google_compute_firewall" "ssh-rule-extended-upgrade" {
+  name    = "vm-ssh-extended-upgrade"
+  network = google_compute_network.vpc_network_extended_upgrade.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "80", "8080", "443", "8443", "9443"]
+  }
+  allow {
+    protocol = "icmp"
+  }
+  target_tags   = ["mirror-ci-rhel-extended-upgrade"]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+output "ip" {
+  value = google_compute_instance.vm_instance_extended_upgrade.network_interface.0.access_config.0.nat_ip
+}

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -230,6 +230,18 @@ jobs:
       - name: Install Registry
         run: ssh ci-user@control './mirror-registry install -u ci-user -r /home/ci-user/quay-install -H quay -v --initPassword password -k ~/.ssh/id_rsa'
 
+      - name: Verify health endpoint
+        run: |
+          ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          services = data.get(\"data\", {}).get(\"services\", {})
+          assert services, \"No services in health response\"
+          for svc, status in services.items():
+              assert status, f\"Service {svc} is not healthy\"
+          print(\"PASS: All services healthy\")
+          "'
+
       - name: Mirror Images
         uses: ./.github/actions/mirror
         with:
@@ -241,6 +253,16 @@ jobs:
 
       - name: Uninstall Registry
         run: ssh ci-user@control './mirror-registry uninstall -u ci-user -H quay --autoApprove -v -k ~/.ssh/id_rsa'
+
+      - name: Verify uninstall completeness
+        run: |
+          ssh ci-user@quay 'bash -e -c "
+            test -z \"\$(podman ps -q -f name=quay 2>/dev/null)\" || { echo FAIL: quay containers still running; exit 1; }
+            ! systemctl --user is-enabled quay-app.service 2>/dev/null || { echo FAIL: quay-app still enabled; exit 1; }
+            ! systemctl --user is-enabled quay-pod.service 2>/dev/null || { echo FAIL: quay-pod still enabled; exit 1; }
+            test ! -d ~/quay-install || { echo FAIL: quay-install dir still exists; exit 1; }
+            echo PASS: uninstall cleanup verified
+          "'
 
       - name: Download old mirror-registry tarball
         run: wget -O mirror-registry-postgres.tar.gz "https://github.com/quay/mirror-registry/releases/download/v1.3.10/mirror-registry-offline.tar.gz"
@@ -379,6 +401,18 @@ jobs:
       - name: Install Registry
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz; ./mirror-registry install -v --quayHostname quay:8443 --initPassword password'
 
+      - name: Verify health endpoint
+        run: |
+          ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          services = data.get(\"data\", {}).get(\"services\", {})
+          assert services, \"No services in health response\"
+          for svc, status in services.items():
+              assert status, f\"Service {svc} is not healthy\"
+          print(\"PASS: All services healthy\")
+          "'
+
       - name: Mirror Images
         uses: ./.github/actions/mirror
         with:
@@ -390,6 +424,16 @@ jobs:
 
       - name: Uninstall Quay
         run: ssh ci-user@quay './mirror-registry uninstall --autoApprove -v'
+
+      - name: Verify uninstall completeness
+        run: |
+          ssh ci-user@quay 'bash -e -c "
+            test -z \"\$(podman ps -q -f name=quay 2>/dev/null)\" || { echo FAIL: quay containers still running; exit 1; }
+            ! systemctl --user is-enabled quay-app.service 2>/dev/null || { echo FAIL: quay-app still enabled; exit 1; }
+            ! systemctl --user is-enabled quay-pod.service 2>/dev/null || { echo FAIL: quay-pod still enabled; exit 1; }
+            test ! -d ~/quay-install || { echo FAIL: quay-install dir still exists; exit 1; }
+            echo PASS: uninstall cleanup verified
+          "'
 
       - name: Download old mirror-registry tarball that runs quay with postgres
         run: wget -O mirror-registry-postgres.tar.gz "https://github.com/quay/mirror-registry/releases/download/v1.3.10/mirror-registry-offline.tar.gz"
@@ -425,6 +469,23 @@ jobs:
         run: ssh ci-user@quay 'podman images | grep -q quay:8443/init/busybox'
 
       - name: Uninstall Quay
+        run: ssh ci-user@quay './mirror-registry uninstall --autoApprove -v'
+
+      - name: Install with custom credentials
+        run: ssh ci-user@quay './mirror-registry install -v --quayHostname quay:8443 --initUser myadmin --initPassword "MyStr0ngP4ss"'
+
+      - name: Verify custom credentials login
+        run: ssh ci-user@quay 'podman login -u myadmin -p "MyStr0ngP4ss" quay:8443 --tls-verify=false'
+
+      - name: Verify default credentials rejected
+        run: |
+          if ssh ci-user@quay 'podman login -u init -p password quay:8443 --tls-verify=false' 2>/dev/null; then
+            echo "FAIL: default credentials should not work"
+            exit 1
+          fi
+          echo "PASS: default credentials correctly rejected"
+
+      - name: Uninstall after custom credentials test
         run: ssh ci-user@quay './mirror-registry uninstall --autoApprove -v'
 
       - name: Terraform Destroy

--- a/.github/workflows/local-offline-installer/main.tf
+++ b/.github/workflows/local-offline-installer/main.tf
@@ -26,7 +26,7 @@ resource "google_compute_network" "vpc_network_local_offline_install" {
 
 resource "google_compute_instance" "vm_instance_local_offline_install" {
   name         = "mirror-ci-rhel-local-offline-install"
-  machine_type = "e2-standard-16"
+  machine_type = "e2-standard-4"
 
   boot_disk {
     initialize_params {

--- a/.github/workflows/local-online-installer/main.tf
+++ b/.github/workflows/local-online-installer/main.tf
@@ -26,7 +26,7 @@ resource "google_compute_network" "vpc_network_local_online_install" {
 
 resource "google_compute_instance" "vm_instance_local_online_install" {
   name         = "mirror-ci-rhel-local-online-install"
-  machine_type = "e2-standard-16"
+  machine_type = "e2-standard-4"
 
   boot_disk {
     initialize_params {

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+      - name: Test
+        run: go test ./... -v

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,6 +1,9 @@
 name: "PR Check"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -8,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   go-validate:
@@ -31,4 +35,12 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./... -v
+        run: go test ./... -v -coverprofile=coverage.out -covermode=atomic
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.out
+          fail_ci_if_error: false

--- a/.github/workflows/remote-offline-installer/main.tf
+++ b/.github/workflows/remote-offline-installer/main.tf
@@ -26,7 +26,7 @@ resource "google_compute_network" "vpc_network_remote_offline_install" {
 
 resource "google_compute_instance" "control_vm_remote_offline_install" {
   name         = "mirror-ci-control-remote-offline-install"
-  machine_type = "e2-standard-16"
+  machine_type = "e2-standard-4"
 
   boot_disk {
     initialize_params {
@@ -61,7 +61,7 @@ resource "google_compute_instance" "control_vm_remote_offline_install" {
 
 resource "google_compute_instance" "target_vm_remote_offline_install" {
   name         = "mirror-ci-target-remote-offline-install"
-  machine_type = "e2-standard-16"
+  machine_type = "e2-standard-4"
 
   boot_disk {
     initialize_params {

--- a/.github/workflows/remote-online-installer/main.tf
+++ b/.github/workflows/remote-online-installer/main.tf
@@ -26,7 +26,7 @@ resource "google_compute_network" "vpc_network_remote_online_install" {
 
 resource "google_compute_instance" "control_vm_remote_online_install" {
   name         = "mirror-ci-control-remote-online-install"
-  machine_type = "e2-standard-16"
+  machine_type = "e2-standard-4"
 
   boot_disk {
     initialize_params {
@@ -61,7 +61,7 @@ resource "google_compute_instance" "control_vm_remote_online_install" {
 
 resource "google_compute_instance" "target_vm_remote_online_install" {
   name         = "mirror-ci-target-remote-online-install"
-  machine_type = "e2-standard-16"
+  machine_type = "e2-standard-4"
 
   boot_disk {
     initialize_params {

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestInstallFlagDefaults(t *testing.T) {
+	flag := installCmd.Flags()
+
+	tests := []struct {
+		name     string
+		flagName string
+		want     string
+	}{
+		{"initUser default", "initUser", "init"},
+		{"initPassword default", "initPassword", ""},
+		{"quayHostname default", "quayHostname", ""},
+		{"imageArchive default", "image-archive", ""},
+		{"sslCert default", "sslCert", ""},
+		{"sslKey default", "sslKey", ""},
+		{"quayRoot default", "quayRoot", "~/quay-install"},
+		{"quayStorage default", "quayStorage", "quay-storage"},
+		{"sqliteStorage default", "sqliteStorage", "sqlite-storage"},
+		{"additionalArgs default", "additionalArgs", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := flag.Lookup(tt.flagName)
+			if f == nil {
+				t.Fatalf("flag %q not registered on install command", tt.flagName)
+			}
+			if f.DefValue != tt.want {
+				t.Errorf("flag %q default = %q, want %q", tt.flagName, f.DefValue, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallBoolFlagDefaults(t *testing.T) {
+	flag := installCmd.Flags()
+
+	tests := []struct {
+		name     string
+		flagName string
+		want     string
+	}{
+		{"sslCheckSkip default", "sslCheckSkip", "false"},
+		{"askBecomePass default", "askBecomePass", "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := flag.Lookup(tt.flagName)
+			if f == nil {
+				t.Fatalf("flag %q not registered on install command", tt.flagName)
+			}
+			if f.DefValue != tt.want {
+				t.Errorf("flag %q default = %q, want %q", tt.flagName, f.DefValue, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallFlagShorthands(t *testing.T) {
+	flag := installCmd.Flags()
+
+	tests := []struct {
+		flagName  string
+		shorthand string
+	}{
+		{"targetHostname", "H"},
+		{"targetUsername", "u"},
+		{"ssh-key", "k"},
+		{"image-archive", "i"},
+		{"quayRoot", "r"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flagName, func(t *testing.T) {
+			f := flag.Lookup(tt.flagName)
+			if f == nil {
+				t.Fatalf("flag %q not registered", tt.flagName)
+			}
+			if f.Shorthand != tt.shorthand {
+				t.Errorf("flag %q shorthand = %q, want %q", tt.flagName, f.Shorthand, tt.shorthand)
+			}
+		})
+	}
+}
+
+func TestUpgradeFlagDefaults(t *testing.T) {
+	flag := upgradeCmd.Flags()
+
+	tests := []struct {
+		name     string
+		flagName string
+		want     string
+	}{
+		{"quayHostname default", "quayHostname", ""},
+		{"quayRoot default", "quayRoot", "~/quay-install"},
+		{"quayStorage default", "quayStorage", "quay-storage"},
+		{"sqliteStorage default", "sqliteStorage", "sqlite-storage"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := flag.Lookup(tt.flagName)
+			if f == nil {
+				t.Fatalf("flag %q not registered on upgrade command", tt.flagName)
+			}
+			if f.DefValue != tt.want {
+				t.Errorf("flag %q default = %q, want %q", tt.flagName, f.DefValue, tt.want)
+			}
+		})
+	}
+}
+
+func TestUninstallFlagDefaults(t *testing.T) {
+	flag := uninstallCmd.Flags()
+
+	tests := []struct {
+		name     string
+		flagName string
+		want     string
+	}{
+		{"targetHostname default", "targetHostname", "localhost"},
+		{"quayRoot default", "quayRoot", "~/quay-install"},
+		{"quayStorage default", "quayStorage", "quay-storage"},
+		{"sqliteStorage default", "sqliteStorage", "sqlite-storage"},
+		{"autoApprove default", "autoApprove", "false"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := flag.Lookup(tt.flagName)
+			if f == nil {
+				t.Fatalf("flag %q not registered on uninstall command", tt.flagName)
+			}
+			if f.DefValue != tt.want {
+				t.Errorf("flag %q default = %q, want %q", tt.flagName, f.DefValue, tt.want)
+			}
+		})
+	}
+}
+
+func TestSshKeyDefault(t *testing.T) {
+	homeDir := os.Getenv("HOME")
+	expected := homeDir + "/.ssh/quay_installer"
+
+	f := installCmd.Flags().Lookup("ssh-key")
+	if f == nil {
+		t.Fatal("ssh-key flag not registered on install command")
+	}
+	if f.DefValue != expected {
+		t.Errorf("ssh-key default = %q, want %q", f.DefValue, expected)
+	}
+}
+
+func TestRootCommandHasSubcommands(t *testing.T) {
+	cmds := rootCmd.Commands()
+	names := make(map[string]bool)
+	for _, c := range cmds {
+		names[c.Name()] = true
+	}
+
+	for _, want := range []string{"install", "upgrade", "uninstall"} {
+		if !names[want] {
+			t.Errorf("root command missing subcommand %q", want)
+		}
+	}
+}
+
+func TestGlobalFlags(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("verbose")
+	if f == nil {
+		t.Fatal("verbose flag not registered")
+	}
+	if f.Shorthand != "v" {
+		t.Errorf("verbose shorthand = %q, want %q", f.Shorthand, "v")
+	}
+
+	f = rootCmd.PersistentFlags().Lookup("no-color")
+	if f == nil {
+		t.Fatal("no-color flag not registered")
+	}
+	if f.Shorthand != "c" {
+		t.Errorf("no-color shorthand = %q, want %q", f.Shorthand, "c")
+	}
+}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -1,0 +1,263 @@
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestPathExists(t *testing.T) {
+	t.Run("existing file", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		if !pathExists(f.Name()) {
+			t.Errorf("pathExists(%q) = false, want true", f.Name())
+		}
+	})
+
+	t.Run("non-existent file", func(t *testing.T) {
+		if pathExists("/nonexistent/path/file.txt") {
+			t.Error("pathExists for nonexistent file = true, want false")
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		dir := t.TempDir()
+		if !pathExists(dir) {
+			t.Errorf("pathExists(%q) = false, want true for directory", dir)
+		}
+	})
+}
+
+func TestGetImageMetadata(t *testing.T) {
+	tests := []struct {
+		app         string
+		imageName   string
+		archivePath string
+		wantContain string
+	}{
+		{
+			app:         "pause",
+			imageName:   "registry.access.redhat.com/ubi8/pause:8.10-5",
+			archivePath: "/tmp/pause.tar",
+			wantContain: "registry.access.redhat.com/ubi8/pause:8.10-5",
+		},
+		{
+			app:         "sqlite",
+			imageName:   "quay.io/projectquay/sqlite-cli:latest",
+			archivePath: "/tmp/sqlite3.tar",
+			wantContain: "sqlite3",
+		},
+		{
+			app:         "ansible",
+			imageName:   "quay.io/quay/mirror-registry-ee:latest",
+			archivePath: "/tmp/ee.tar",
+			wantContain: "ansible-runner",
+		},
+		{
+			app:         "redis",
+			imageName:   "registry.redhat.io/rhel8/redis-6:1",
+			archivePath: "/tmp/redis.tar",
+			wantContain: "REDIS_VERSION=6",
+		},
+		{
+			app:         "quay",
+			imageName:   "registry.redhat.io/quay/quay-rhel8:v3.12.14",
+			archivePath: "/tmp/quay.tar",
+			wantContain: "RED_HAT_QUAY=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.app, func(t *testing.T) {
+			result := getImageMetadata(tt.app, tt.imageName, tt.archivePath)
+			if result == "" {
+				t.Fatal("getImageMetadata returned empty string")
+			}
+			if !strings.Contains(result, tt.wantContain) {
+				t.Errorf("getImageMetadata(%q, ...) missing %q", tt.app, tt.wantContain)
+			}
+			if !strings.Contains(result, "/usr/bin/podman image import") {
+				t.Errorf("getImageMetadata(%q, ...) missing podman import command", tt.app)
+			}
+			if !strings.Contains(result, tt.imageName) {
+				t.Errorf("getImageMetadata(%q, ...) missing image name %q", tt.app, tt.imageName)
+			}
+			if !strings.Contains(result, tt.archivePath) {
+				t.Errorf("getImageMetadata(%q, ...) missing archive path %q", tt.app, tt.archivePath)
+			}
+		})
+	}
+
+	t.Run("unknown app returns empty", func(t *testing.T) {
+		result := getImageMetadata("unknown", "img:latest", "/tmp/archive.tar")
+		if result != "" {
+			t.Errorf("getImageMetadata for unknown app = %q, want empty", result)
+		}
+	})
+}
+
+// generateTestCertificate creates a self-signed cert/key pair for testing.
+// Returns paths to the cert and key files in the given directory.
+func generateTestCertificate(t *testing.T, dir, hostname string) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: hostname},
+		DNSNames:     []string{hostname},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certPath = filepath.Join(dir, "test.cert")
+	keyPath = filepath.Join(dir, "test.key")
+
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	certFile.Close()
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pem.Encode(keyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyFile.Close()
+
+	return certPath, keyPath
+}
+
+func init() {
+	log.SetFormatter(&logrus.TextFormatter{})
+}
+
+func TestLoadCerts(t *testing.T) {
+	t.Run("empty cert and key paths returns nil", func(t *testing.T) {
+		err := loadCerts("", "", "example.com", false)
+		if err != nil {
+			t.Errorf("loadCerts with empty paths returned error: %v", err)
+		}
+	})
+
+	t.Run("valid cert matching hostname", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := generateTestCertificate(t, dir, "myhost.example.com")
+
+		err := loadCerts(certPath, keyPath, "myhost.example.com", false)
+		if err != nil {
+			t.Errorf("loadCerts with valid cert returned error: %v", err)
+		}
+	})
+
+	t.Run("cert hostname mismatch fails", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := generateTestCertificate(t, dir, "correct.example.com")
+
+		err := loadCerts(certPath, keyPath, "wrong.example.com", false)
+		if err == nil {
+			t.Error("loadCerts with hostname mismatch should return error")
+		}
+	})
+
+	t.Run("cert hostname mismatch with skipCheck succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, keyPath := generateTestCertificate(t, dir, "correct.example.com")
+
+		err := loadCerts(certPath, keyPath, "wrong.example.com", true)
+		if err != nil {
+			t.Errorf("loadCerts with skipCheck=true returned error: %v", err)
+		}
+	})
+
+	t.Run("nonexistent cert file fails", func(t *testing.T) {
+		dir := t.TempDir()
+		_, keyPath := generateTestCertificate(t, dir, "test.example.com")
+
+		err := loadCerts("/nonexistent/cert.pem", keyPath, "test.example.com", true)
+		if err == nil {
+			t.Error("loadCerts with nonexistent cert should return error")
+		}
+	})
+
+	t.Run("nonexistent key file fails", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath, _ := generateTestCertificate(t, dir, "test.example.com")
+
+		err := loadCerts(certPath, "/nonexistent/key.pem", "test.example.com", true)
+		if err == nil {
+			t.Error("loadCerts with nonexistent key should return error")
+		}
+	})
+
+	t.Run("malformed cert file fails", func(t *testing.T) {
+		dir := t.TempDir()
+		certPath := filepath.Join(dir, "bad.cert")
+		keyPath := filepath.Join(dir, "bad.key")
+		os.WriteFile(certPath, []byte("not a certificate"), 0644)
+		os.WriteFile(keyPath, []byte("not a key"), 0644)
+
+		err := loadCerts(certPath, keyPath, "test.example.com", false)
+		if err == nil {
+			t.Error("loadCerts with malformed cert should return error")
+		}
+	})
+}
+
+func TestIsLocalInstall(t *testing.T) {
+	// Save and restore package-level vars
+	origHostname := targetHostname
+	origUsername := targetUsername
+	defer func() {
+		targetHostname = origHostname
+		targetUsername = origUsername
+	}()
+
+	t.Run("localhost is always local", func(t *testing.T) {
+		targetHostname = "localhost"
+		targetUsername = "someuser"
+		if !isLocalInstall() {
+			t.Error("isLocalInstall() = false for localhost, want true")
+		}
+	})
+
+	t.Run("remote hostname is not local", func(t *testing.T) {
+		targetHostname = "remote.example.com"
+		targetUsername = os.Getenv("USER")
+		if isLocalInstall() {
+			t.Error("isLocalInstall() = true for remote host, want false")
+		}
+	})
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "20...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+ignore:
+  - "vendor/**"
+  - "test/**"
+  - "agent_docs/**"
+  - "ansible-runner/**"
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -2,11 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/fedora37"
+  config.vm.box = "generic/centos9s"
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 8443, host: 8443
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "3072"
+    vb.memory = "4096"
   end
   config.vm.provision "shell", inline: <<-SHELL
     dnf install -y \

--- a/test/e2e/lib.sh
+++ b/test/e2e/lib.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Shared test helper library for mirror-registry e2e tests.
+# Source this file from individual test scripts: source "$(dirname "$0")/lib.sh"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# Colors (disabled if NO_COLOR is set)
+if [[ -z "${NO_COLOR:-}" ]]; then
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    NC='\033[0m'
+else
+    GREEN='' RED='' YELLOW='' NC=''
+fi
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_error() { echo -e "${RED}[FAIL]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+
+assert_success() {
+    local description="$1"
+    shift
+    if "$@"; then
+        log_info "PASS: ${description}"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: ${description}"
+        log_error "  Command: $*"
+        ((FAIL_COUNT++))
+    fi
+}
+
+assert_failure() {
+    local description="$1"
+    shift
+    if "$@" 2>/dev/null; then
+        log_error "FAIL: ${description} (expected failure but succeeded)"
+        ((FAIL_COUNT++))
+    else
+        log_info "PASS: ${description}"
+        ((PASS_COUNT++))
+    fi
+}
+
+assert_contains() {
+    local description="$1"
+    local haystack="$2"
+    local needle="$3"
+    if echo "${haystack}" | grep -q "${needle}"; then
+        log_info "PASS: ${description}"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: ${description}"
+        log_error "  Expected to find: ${needle}"
+        ((FAIL_COUNT++))
+    fi
+}
+
+assert_file_exists() {
+    local description="$1"
+    local filepath="$2"
+    if [[ -e "${filepath}" ]]; then
+        log_info "PASS: ${description}"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: ${description}"
+        log_error "  File not found: ${filepath}"
+        ((FAIL_COUNT++))
+    fi
+}
+
+assert_file_not_exists() {
+    local description="$1"
+    local filepath="$2"
+    if [[ ! -e "${filepath}" ]]; then
+        log_info "PASS: ${description}"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: ${description}"
+        log_error "  File should not exist: ${filepath}"
+        ((FAIL_COUNT++))
+    fi
+}
+
+# Wait for Quay health endpoint to become healthy (up to timeout seconds)
+wait_for_quay() {
+    local hostname="${1:-localhost:8443}"
+    local timeout="${2:-120}"
+    local elapsed=0
+    log_info "Waiting for Quay at ${hostname} to become healthy (timeout: ${timeout}s)..."
+    while [[ ${elapsed} -lt ${timeout} ]]; do
+        if curl -sk "https://${hostname}/health/instance" 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    services = data.get('data', {}).get('services', {})
+    if services and all(services.values()):
+        sys.exit(0)
+except:
+    pass
+sys.exit(1)
+" 2>/dev/null; then
+            log_info "Quay is healthy after ${elapsed}s"
+            return 0
+        fi
+        sleep 5
+        ((elapsed+=5))
+    done
+    log_error "Quay did not become healthy within ${timeout}s"
+    return 1
+}
+
+assert_quay_healthy() {
+    local hostname="${1:-localhost:8443}"
+    local response
+    response=$(curl -sk "https://${hostname}/health/instance" 2>/dev/null)
+    if [[ -z "${response}" ]]; then
+        log_error "FAIL: Health endpoint returned empty response"
+        ((FAIL_COUNT++))
+        return 1
+    fi
+
+    if echo "${response}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+services = data.get('data', {}).get('services', {})
+assert services, 'No services in health response'
+for svc, status in services.items():
+    assert status, f'Service {svc} is not healthy'
+print('All services healthy')
+" 2>/dev/null; then
+        log_info "PASS: Quay health check"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: Quay health check"
+        log_error "  Response: ${response}"
+        ((FAIL_COUNT++))
+    fi
+}
+
+assert_services_running() {
+    local use_sudo="${1:-false}"
+    local systemctl_cmd="systemctl --user"
+    if [[ "${use_sudo}" == "true" ]]; then
+        systemctl_cmd="sudo systemctl"
+    fi
+
+    for svc in quay-pod quay-app quay-redis; do
+        if ${systemctl_cmd} is-active "${svc}.service" &>/dev/null; then
+            log_info "PASS: ${svc}.service is active"
+            ((PASS_COUNT++))
+        else
+            log_error "FAIL: ${svc}.service is not active"
+            ((FAIL_COUNT++))
+        fi
+    done
+}
+
+assert_clean_uninstall() {
+    local quay_root="${1:-~/quay-install}"
+    local use_sudo="${2:-false}"
+    local systemctl_cmd="systemctl --user"
+    if [[ "${use_sudo}" == "true" ]]; then
+        systemctl_cmd="sudo systemctl"
+    fi
+
+    # No quay containers running
+    local containers
+    containers=$(podman ps -q -f name=quay 2>/dev/null || true)
+    if [[ -z "${containers}" ]]; then
+        log_info "PASS: No quay containers running"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: Quay containers still running: ${containers}"
+        ((FAIL_COUNT++))
+    fi
+
+    # No systemd services enabled
+    for svc in quay-app quay-pod quay-redis; do
+        if ! ${systemctl_cmd} is-enabled "${svc}.service" &>/dev/null; then
+            log_info "PASS: ${svc}.service is not enabled"
+            ((PASS_COUNT++))
+        else
+            log_error "FAIL: ${svc}.service is still enabled"
+            ((FAIL_COUNT++))
+        fi
+    done
+
+    # quay-install directory removed
+    eval local expanded_root="${quay_root}"
+    if [[ ! -d "${expanded_root}" ]]; then
+        log_info "PASS: ${quay_root} directory removed"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: ${quay_root} directory still exists"
+        ((FAIL_COUNT++))
+    fi
+}
+
+# Generate a self-signed CA and server certificate for testing
+generate_test_certs() {
+    local cert_dir="$1"
+    local hostname="$2"
+
+    mkdir -p "${cert_dir}"
+
+    # Generate CA key and cert
+    openssl genrsa -out "${cert_dir}/ca.key" 2048 2>/dev/null
+    openssl req -x509 -new -nodes \
+        -key "${cert_dir}/ca.key" \
+        -sha256 -days 1 \
+        -out "${cert_dir}/ca.pem" \
+        -subj "/CN=Test CA" 2>/dev/null
+
+    # Generate server key
+    openssl genrsa -out "${cert_dir}/server.key" 2048 2>/dev/null
+
+    # Generate server CSR
+    openssl req -new \
+        -key "${cert_dir}/server.key" \
+        -out "${cert_dir}/server.csr" \
+        -subj "/CN=${hostname}" 2>/dev/null
+
+    # Create extensions file for SAN
+    cat > "${cert_dir}/ext.cnf" <<EXTEOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = DNS:${hostname}
+EXTEOF
+
+    # Sign server cert with CA
+    openssl x509 -req \
+        -in "${cert_dir}/server.csr" \
+        -CA "${cert_dir}/ca.pem" \
+        -CAkey "${cert_dir}/ca.key" \
+        -CAcreateserial \
+        -out "${cert_dir}/server.cert" \
+        -days 1 \
+        -sha256 \
+        -extfile "${cert_dir}/ext.cnf" 2>/dev/null
+
+    log_info "Generated test certificates for ${hostname} in ${cert_dir}"
+}
+
+# Push and pull a busybox image to verify registry functionality
+verify_push_pull() {
+    local hostname="${1:-localhost:8443}"
+    local username="${2:-init}"
+    local password="${3:-password}"
+    local tls_verify="${4:---tls-verify=false}"
+
+    log_info "Testing push/pull to ${hostname} as ${username}..."
+
+    podman login -u "${username}" -p "${password}" "${hostname}" ${tls_verify}
+    podman pull docker.io/library/busybox 2>/dev/null || true
+    podman tag docker.io/library/busybox "${hostname}/${username}/busybox:test"
+    podman push "${hostname}/${username}/busybox:test" ${tls_verify}
+
+    # Remove local copy and pull back
+    podman rmi "${hostname}/${username}/busybox:test" 2>/dev/null || true
+    podman pull "${hostname}/${username}/busybox:test" ${tls_verify}
+
+    if podman images | grep -q "${hostname}/${username}/busybox"; then
+        log_info "PASS: Push/pull verification"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: Push/pull verification"
+        ((FAIL_COUNT++))
+    fi
+
+    # Cleanup
+    podman rmi "${hostname}/${username}/busybox:test" 2>/dev/null || true
+}
+
+print_summary() {
+    echo ""
+    echo "=============================="
+    echo "Test Summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+    echo "=============================="
+    if [[ ${FAIL_COUNT} -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}

--- a/test/e2e/test-auto-password.sh
+++ b/test/e2e/test-auto-password.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# P2-5: Test that install generates and displays a random password
+# when --initPassword is not provided.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+log_info "=== Test: Auto-Generated Password ==="
+
+# Install without --initPassword
+log_info "Installing without --initPassword..."
+install_output=$( ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" 2>&1 )
+
+wait_for_quay "${QUAY_ENDPOINT}"
+
+# The install output should contain the generated password
+# Format: "Quay is available at https://host:8443 with credentials (init, <password>)"
+if echo "${install_output}" | grep -q "credentials (init,"; then
+    log_info "PASS: Install output contains generated credentials"
+    ((PASS_COUNT++))
+
+    # Extract the password from output
+    generated_password=$(echo "${install_output}" | grep "credentials (init," | sed 's/.*credentials (init, \(.*\))/\1/' | tr -d ')')
+    log_info "Generated password length: ${#generated_password}"
+
+    if [[ ${#generated_password} -gt 8 ]]; then
+        log_info "PASS: Generated password has sufficient length"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: Generated password too short: ${#generated_password} chars"
+        ((FAIL_COUNT++))
+    fi
+
+    # Verify we can login with the generated password
+    if podman login -u init -p "${generated_password}" "${QUAY_ENDPOINT}" --tls-verify=false 2>/dev/null; then
+        log_info "PASS: Login succeeded with generated password"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: Login failed with generated password"
+        ((FAIL_COUNT++))
+    fi
+else
+    log_error "FAIL: Install output does not contain generated credentials"
+    log_error "  Output: ${install_output}"
+    ((FAIL_COUNT++))
+fi
+
+# Cleanup
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+print_summary

--- a/test/e2e/test-custom-hostname.sh
+++ b/test/e2e/test-custom-hostname.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# P1-1: Test installation with custom quayHostname that differs from targetHostname.
+#
+# Installs with --quayHostname set to a value different from the target host's
+# actual hostname. Verifies SERVER_HOSTNAME in config.yaml is correct and
+# Quay is accessible at the custom hostname.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+ACTUAL_HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+CUSTOM_HOSTNAME="custom-registry.local"
+CUSTOM_ENDPOINT="${CUSTOM_HOSTNAME}:8443"
+
+log_info "=== Test: Custom quayHostname Install ==="
+log_info "Actual hostname: ${ACTUAL_HOSTNAME}"
+log_info "Custom quayHostname: ${CUSTOM_ENDPOINT}"
+
+# Add custom hostname to /etc/hosts pointing to localhost
+echo "127.0.0.1 ${CUSTOM_HOSTNAME}" | sudo tee -a /etc/hosts
+
+# Install with custom quayHostname
+log_info "Installing with custom quayHostname..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${CUSTOM_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${CUSTOM_ENDPOINT}"
+assert_quay_healthy "${CUSTOM_ENDPOINT}"
+
+# Verify config.yaml has the custom hostname
+config_hostname=$(grep "SERVER_HOSTNAME" ~/quay-install/quay-config/config.yaml 2>/dev/null | head -1 || echo "")
+assert_contains "SERVER_HOSTNAME set to custom hostname" "${config_hostname}" "${CUSTOM_ENDPOINT}"
+
+# Verify Quay is accessible at custom hostname
+assert_success "Quay accessible at custom hostname" \
+    curl -sk --connect-timeout 10 "https://${CUSTOM_ENDPOINT}/health/instance"
+
+# Verify login works with custom hostname
+assert_success "Podman login at custom hostname" \
+    podman login -u init -p password "${CUSTOM_ENDPOINT}" --tls-verify=false
+
+# Push/pull with custom hostname
+verify_push_pull "${CUSTOM_ENDPOINT}" "init" "password" "--tls-verify=false"
+
+# Uninstall
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+assert_clean_uninstall
+
+print_summary

--- a/test/e2e/test-custom-paths.sh
+++ b/test/e2e/test-custom-paths.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# P1-2/P1-3: Test installation with custom quayRoot and filesystem storage paths.
+#
+# Installs with --quayRoot, --quayStorage, --sqliteStorage set to filesystem
+# paths instead of default named volumes. Verifies directories are created,
+# push/pull works, and uninstall cleans everything up.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+CUSTOM_ROOT="/opt/quay-data"
+CUSTOM_STORAGE="/data/quay-blobs"
+CUSTOM_SQLITE="/data/quay-db"
+
+log_info "=== Test: Custom Paths Install ==="
+log_info "quayRoot: ${CUSTOM_ROOT}"
+log_info "quayStorage: ${CUSTOM_STORAGE}"
+log_info "sqliteStorage: ${CUSTOM_SQLITE}"
+
+# Create parent directories
+sudo mkdir -p /opt /data
+sudo chmod 777 /opt /data
+
+# Install with custom paths
+log_info "Installing with custom paths..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password \
+    --quayRoot "${CUSTOM_ROOT}" \
+    --quayStorage "${CUSTOM_STORAGE}" \
+    --sqliteStorage "${CUSTOM_SQLITE}"
+
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+
+# Verify custom directories exist
+assert_file_exists "quayRoot directory created" "${CUSTOM_ROOT}"
+assert_file_exists "quayStorage directory created" "${CUSTOM_STORAGE}"
+assert_file_exists "sqliteStorage directory created" "${CUSTOM_SQLITE}"
+
+# Verify config files are in custom root
+assert_file_exists "config.yaml in custom quayRoot" "${CUSTOM_ROOT}/quay-config/config.yaml"
+
+# Push/pull test
+verify_push_pull "${QUAY_ENDPOINT}" "init" "password" "--tls-verify=false"
+
+# Uninstall with custom paths
+log_info "Uninstalling with custom paths..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v \
+    --quayRoot "${CUSTOM_ROOT}" \
+    --quayStorage "${CUSTOM_STORAGE}" \
+    --sqliteStorage "${CUSTOM_SQLITE}"
+
+# Verify cleanup
+assert_file_not_exists "quayRoot removed after uninstall" "${CUSTOM_ROOT}"
+
+# Verify no services remain
+local_containers=$(podman ps -q -f name=quay 2>/dev/null || true)
+if [[ -z "${local_containers}" ]]; then
+    log_info "PASS: No quay containers running after uninstall"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Quay containers still running"
+    ((FAIL_COUNT++))
+fi
+
+print_summary

--- a/test/e2e/test-custom-tls.sh
+++ b/test/e2e/test-custom-tls.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# P0-6: Test installation with custom TLS certificates.
+#
+# Generates a CA + server certificate, installs mirror-registry with
+# --sslCert/--sslKey, and verifies HTTPS works with that certificate.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+CERT_DIR="/tmp/test-tls-certs"
+
+log_info "=== Test: Custom TLS Certificate Install ==="
+log_info "Hostname: ${HOSTNAME}"
+
+# Generate test CA and server cert
+generate_test_certs "${CERT_DIR}" "${HOSTNAME}"
+
+# Install with custom certificates
+log_info "Installing with custom TLS certificates..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password \
+    --sslCert "${CERT_DIR}/server.cert" \
+    --sslKey "${CERT_DIR}/server.key"
+
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+
+# Verify the certificate is the one we provided
+log_info "Verifying server certificate matches provided cert..."
+server_serial=$(echo | openssl s_client -connect "${QUAY_ENDPOINT}" -servername "${HOSTNAME}" 2>/dev/null | openssl x509 -noout -serial 2>/dev/null || echo "CONNECT_FAILED")
+provided_serial=$(openssl x509 -in "${CERT_DIR}/server.cert" -noout -serial 2>/dev/null)
+
+if [[ "${server_serial}" == "${provided_serial}" ]]; then
+    log_info "PASS: Server is using the provided certificate"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Server certificate does not match provided cert"
+    log_error "  Server serial:   ${server_serial}"
+    log_error "  Provided serial: ${provided_serial}"
+    ((FAIL_COUNT++))
+fi
+
+# Verify we can login using the CA to trust the cert
+log_info "Verifying podman login with CA trust..."
+mkdir -p "/etc/containers/certs.d/${QUAY_ENDPOINT}"
+cp "${CERT_DIR}/ca.pem" "/etc/containers/certs.d/${QUAY_ENDPOINT}/ca.crt" 2>/dev/null || \
+    sudo cp "${CERT_DIR}/ca.pem" "/etc/containers/certs.d/${QUAY_ENDPOINT}/ca.crt"
+
+assert_success "Podman login with custom CA" \
+    podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+
+# Push/pull test
+verify_push_pull "${QUAY_ENDPOINT}" "init" "password" "--tls-verify=false"
+
+# Uninstall
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+assert_clean_uninstall
+
+# Cleanup
+rm -rf "${CERT_DIR}"
+
+print_summary

--- a/test/e2e/test-error-invalid-cert.sh
+++ b/test/e2e/test-error-invalid-cert.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# P2-3: Test that install fails with a clear error for malformed certificates.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+CERT_DIR="/tmp/test-invalid-certs"
+
+log_info "=== Test: Error - Invalid Certificate ==="
+
+mkdir -p "${CERT_DIR}"
+
+# Test 1: Malformed cert file (not PEM)
+log_info "Test 1: Malformed certificate file..."
+echo "this is not a certificate" > "${CERT_DIR}/bad.cert"
+echo "this is not a key" > "${CERT_DIR}/bad.key"
+
+install_output=$( ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password \
+    --sslCert "${CERT_DIR}/bad.cert" \
+    --sslKey "${CERT_DIR}/bad.key" 2>&1 ) && install_rc=0 || install_rc=$?
+
+if [[ ${install_rc} -ne 0 ]]; then
+    log_info "PASS: Install rejected malformed certificate"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Install accepted malformed certificate"
+    ((FAIL_COUNT++))
+    ${MIRROR_REGISTRY} uninstall --autoApprove -v 2>/dev/null || true
+fi
+
+# Test 2: Nonexistent cert file
+log_info "Test 2: Nonexistent certificate file..."
+install_output=$( ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password \
+    --sslCert "/nonexistent/cert.pem" \
+    --sslKey "/nonexistent/key.pem" 2>&1 ) && install_rc=0 || install_rc=$?
+
+if [[ ${install_rc} -ne 0 ]]; then
+    log_info "PASS: Install rejected nonexistent certificate files"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Install accepted nonexistent certificate files"
+    ((FAIL_COUNT++))
+    ${MIRROR_REGISTRY} uninstall --autoApprove -v 2>/dev/null || true
+fi
+
+# Cleanup
+rm -rf "${CERT_DIR}"
+
+print_summary

--- a/test/e2e/test-error-no-podman.sh
+++ b/test/e2e/test-error-no-podman.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# P2-1: Test that install fails clearly when podman is not installed.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+log_info "=== Test: Error - Missing Podman ==="
+
+# Remove podman
+log_info "Removing podman..."
+sudo yum -y remove podman 2>/dev/null || sudo dnf -y remove podman 2>/dev/null || true
+
+# Verify podman is gone
+if command -v podman &>/dev/null; then
+    log_warn "podman still available, skipping test"
+    # Reinstall for subsequent tests
+    sudo yum -y install podman 2>/dev/null || sudo dnf -y install podman 2>/dev/null || true
+    exit 0
+fi
+
+# Attempt install — should fail
+log_info "Attempting install without podman..."
+install_output=$( ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password 2>&1 ) && install_rc=0 || install_rc=$?
+
+if [[ ${install_rc} -ne 0 ]]; then
+    log_info "PASS: Install failed as expected (exit code ${install_rc})"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Install succeeded without podman"
+    ((FAIL_COUNT++))
+fi
+
+# Reinstall podman for subsequent tests
+log_info "Reinstalling podman..."
+sudo yum -y install podman 2>/dev/null || sudo dnf -y install podman 2>/dev/null || true
+
+print_summary

--- a/test/e2e/test-health-endpoint.sh
+++ b/test/e2e/test-health-endpoint.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# P2-6: Deep validation of the /health/instance JSON response.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+log_info "=== Test: Health Endpoint Deep Validation ==="
+
+# Install
+log_info "Installing..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+
+# Fetch health endpoint
+response=$(curl -sk "https://${QUAY_ENDPOINT}/health/instance" 2>/dev/null)
+
+if [[ -z "${response}" ]]; then
+    log_error "FAIL: Health endpoint returned empty response"
+    ((FAIL_COUNT++))
+else
+    log_info "PASS: Health endpoint returned response"
+    ((PASS_COUNT++))
+fi
+
+# Validate JSON structure
+python3 -c "
+import sys, json
+
+data = json.loads('''${response}''')
+
+# Check top-level structure
+assert 'data' in data, 'Missing data field'
+assert 'services' in data['data'], 'Missing services field'
+
+services = data['data']['services']
+print(f'Found {len(services)} services: {list(services.keys())}')
+
+# Check all services are healthy
+all_healthy = True
+for svc, status in services.items():
+    if status:
+        print(f'  {svc}: healthy')
+    else:
+        print(f'  {svc}: UNHEALTHY')
+        all_healthy = False
+
+if all_healthy:
+    print('ALL SERVICES HEALTHY')
+    sys.exit(0)
+else:
+    print('SOME SERVICES UNHEALTHY')
+    sys.exit(1)
+" && {
+    log_info "PASS: All health services report healthy"
+    ((PASS_COUNT++))
+} || {
+    log_error "FAIL: Health endpoint validation failed"
+    ((FAIL_COUNT++))
+}
+
+# Verify response has expected content type behavior
+http_code=$(curl -sk -o /dev/null -w "%{http_code}" "https://${QUAY_ENDPOINT}/health/instance" 2>/dev/null)
+if [[ "${http_code}" == "200" ]]; then
+    log_info "PASS: Health endpoint returns HTTP 200"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Health endpoint returned HTTP ${http_code}"
+    ((FAIL_COUNT++))
+fi
+
+# Cleanup
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+print_summary

--- a/test/e2e/test-idempotent-reinstall.sh
+++ b/test/e2e/test-idempotent-reinstall.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# P1-5: Test idempotent reinstall (install over existing without uninstall).
+#
+# Installs mirror-registry, pushes data, then installs again without
+# uninstalling first. Verifies the second install either succeeds
+# gracefully or fails with a clear error.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+log_info "=== Test: Idempotent Reinstall ==="
+
+# First install
+log_info "First install..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+
+# Push test data
+log_info "Pushing test image..."
+podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+podman pull docker.io/library/busybox 2>/dev/null || true
+podman tag docker.io/library/busybox "${QUAY_ENDPOINT}/init/reinstall-test:v1"
+podman push "${QUAY_ENDPOINT}/init/reinstall-test:v1" --tls-verify=false
+
+# Second install over existing (without uninstall)
+log_info "Second install (over existing)..."
+reinstall_output=$( ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password 2>&1 ) && reinstall_rc=0 || reinstall_rc=$?
+
+if [[ ${reinstall_rc} -eq 0 ]]; then
+    log_info "PASS: Reinstall succeeded (idempotent behavior)"
+    ((PASS_COUNT++))
+
+    wait_for_quay "${QUAY_ENDPOINT}"
+    assert_quay_healthy "${QUAY_ENDPOINT}"
+else
+    # If reinstall fails, it should at least produce a clear error
+    log_warn "Reinstall failed with exit code ${reinstall_rc}"
+    if echo "${reinstall_output}" | grep -qi "already\|exist\|running\|conflict"; then
+        log_info "PASS: Reinstall failed with descriptive error message"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: Reinstall failed without a clear error message"
+        log_error "  Output: ${reinstall_output}"
+        ((FAIL_COUNT++))
+    fi
+fi
+
+# Cleanup
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+print_summary

--- a/test/e2e/test-nonstandard-port.sh
+++ b/test/e2e/test-nonstandard-port.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# P2-4: Test installation with a non-standard port via --quayHostname.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+CUSTOM_PORT="9443"
+QUAY_ENDPOINT="${HOSTNAME}:${CUSTOM_PORT}"
+
+log_info "=== Test: Non-Standard Port (${CUSTOM_PORT}) ==="
+
+# Install with non-standard port
+log_info "Installing with port ${CUSTOM_PORT}..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+
+# Verify the port is actually listening on the custom port
+if ss -tlnp 2>/dev/null | grep -q ":${CUSTOM_PORT} "; then
+    log_info "PASS: Port ${CUSTOM_PORT} is listening"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Port ${CUSTOM_PORT} is not listening"
+    ((FAIL_COUNT++))
+fi
+
+# Verify default port 8443 is NOT listening
+if ! ss -tlnp 2>/dev/null | grep -q ":8443 "; then
+    log_info "PASS: Default port 8443 is not listening"
+    ((PASS_COUNT++))
+else
+    log_warn "Port 8443 is also listening (may be expected if pod publishes both)"
+fi
+
+# Login and push/pull on custom port
+assert_success "Podman login on port ${CUSTOM_PORT}" \
+    podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+
+verify_push_pull "${QUAY_ENDPOINT}" "init" "password" "--tls-verify=false"
+
+# Cleanup
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+print_summary

--- a/test/e2e/test-root-install.sh
+++ b/test/e2e/test-root-install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# P0-8: Test root (sudo) installation.
+#
+# Installs mirror-registry as root and verifies systemd services are
+# created in /etc/systemd/system/ (system scope, not user scope).
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+log_info "=== Test: Root (sudo) Install ==="
+log_info "Hostname: ${HOSTNAME}"
+
+# Install as root
+log_info "Installing as root..."
+sudo ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+
+# Verify systemd services are in system scope (/etc/systemd/system/)
+for svc in quay-pod quay-app quay-redis; do
+    if [[ -f "/etc/systemd/system/${svc}.service" ]]; then
+        log_info "PASS: ${svc}.service in /etc/systemd/system/ (system scope)"
+        ((PASS_COUNT++))
+    else
+        log_error "FAIL: ${svc}.service not found in /etc/systemd/system/"
+        ((FAIL_COUNT++))
+    fi
+done
+
+# Verify services are running under system scope
+assert_services_running "true"
+
+# Verify push/pull works
+verify_push_pull "${QUAY_ENDPOINT}" "init" "password" "--tls-verify=false"
+
+# Uninstall as root
+log_info "Uninstalling as root..."
+sudo ${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+assert_clean_uninstall "~/quay-install" "true"
+
+# Verify system-scope unit files are removed
+for svc in quay-pod quay-app quay-redis; do
+    assert_file_not_exists "${svc}.service removed from /etc/systemd/system/" \
+        "/etc/systemd/system/${svc}.service"
+done
+
+print_summary

--- a/test/e2e/test-tls-mismatch.sh
+++ b/test/e2e/test-tls-mismatch.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# P1-7: Test TLS certificate hostname mismatch and --sslCheckSkip.
+#
+# Generates a certificate for a wrong hostname, verifies install rejects it,
+# then re-tests with --sslCheckSkip to confirm the bypass works.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+CERT_DIR="/tmp/test-tls-mismatch"
+WRONG_HOSTNAME="wrong-host.example.com"
+
+log_info "=== Test: TLS Certificate Hostname Mismatch ==="
+log_info "Actual hostname: ${HOSTNAME}"
+log_info "Certificate hostname: ${WRONG_HOSTNAME}"
+
+# Generate cert for the WRONG hostname
+generate_test_certs "${CERT_DIR}" "${WRONG_HOSTNAME}"
+
+# Attempt install with mismatched cert — should fail
+log_info "Installing with mismatched certificate (should fail)..."
+if ${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password \
+    --sslCert "${CERT_DIR}/server.cert" \
+    --sslKey "${CERT_DIR}/server.key" 2>&1; then
+    log_error "FAIL: Install should have rejected mismatched certificate"
+    ((FAIL_COUNT++))
+    # Clean up if it somehow installed
+    ${MIRROR_REGISTRY} uninstall --autoApprove -v 2>/dev/null || true
+else
+    log_info "PASS: Install correctly rejected mismatched certificate"
+    ((PASS_COUNT++))
+fi
+
+# Now install with --sslCheckSkip — should succeed
+log_info "Installing with --sslCheckSkip (should succeed)..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password \
+    --sslCert "${CERT_DIR}/server.cert" \
+    --sslKey "${CERT_DIR}/server.key" \
+    --sslCheckSkip
+
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+log_info "PASS: Install succeeded with --sslCheckSkip"
+((PASS_COUNT++))
+
+# Verify we can still login (using tls-verify=false since cert is for wrong host)
+assert_success "Login works with --sslCheckSkip install" \
+    podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+
+# Cleanup
+log_info "Uninstalling..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+rm -rf "${CERT_DIR}"
+
+print_summary

--- a/test/e2e/test-uninstall-verification.sh
+++ b/test/e2e/test-uninstall-verification.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# P0-9: Comprehensive uninstall verification.
+#
+# Installs mirror-registry, pushes an image, then uninstalls and verifies
+# that all artifacts are completely cleaned up.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+log_info "=== Test: Uninstall Completeness Verification ==="
+log_info "Hostname: ${HOSTNAME}"
+
+# Install
+log_info "Installing..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+
+# Push a test image to ensure data exists
+verify_push_pull "${QUAY_ENDPOINT}" "init" "password" "--tls-verify=false"
+
+# Uninstall
+log_info "Uninstalling with --autoApprove..."
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+# Comprehensive cleanup checks
+assert_clean_uninstall
+
+# Verify no quay-related podman pods exist
+pods=$(podman pod ls --format "{{.Name}}" 2>/dev/null | grep -i quay || true)
+if [[ -z "${pods}" ]]; then
+    log_info "PASS: No quay podman pods exist"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Quay pods still exist: ${pods}"
+    ((FAIL_COUNT++))
+fi
+
+# Verify port 8443 is no longer in use
+if ! ss -tlnp 2>/dev/null | grep -q ":8443 "; then
+    log_info "PASS: Port 8443 is free"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Port 8443 is still in use"
+    ((FAIL_COUNT++))
+fi
+
+# Verify the health endpoint is no longer accessible
+if ! curl -sk --connect-timeout 5 "https://${QUAY_ENDPOINT}/health/instance" &>/dev/null; then
+    log_info "PASS: Health endpoint is no longer accessible"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Health endpoint still accessible after uninstall"
+    ((FAIL_COUNT++))
+fi
+
+print_summary

--- a/test/e2e/test-upgrade-sqlite.sh
+++ b/test/e2e/test-upgrade-sqlite.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# P1-6: Test SQLite-to-SQLite upgrade path (recent release -> current build).
+#
+# Downloads the latest released version, installs it, pushes data, upgrades
+# to the current PR build, and verifies data is preserved. This tests the
+# common upgrade path (not the legacy postgres migration).
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY_DIR="${1:-.}"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+QUAY_ENDPOINT="${HOSTNAME}:8443"
+
+# Version to upgrade from — should be a recent SQLite-based release
+OLD_VERSION="${OLD_VERSION:-2.0.2}"
+OLD_TARBALL="mirror-registry-old.tar.gz"
+OLD_DIR="mirror-registry-old"
+
+log_info "=== Test: SQLite-to-SQLite Upgrade ==="
+log_info "Upgrading from v${OLD_VERSION} to current build"
+
+# Download old version
+log_info "Downloading v${OLD_VERSION}..."
+wget -q -O "${OLD_TARBALL}" \
+    "https://github.com/quay/mirror-registry/releases/download/v${OLD_VERSION}/mirror-registry-offline.tar.gz" || {
+    log_warn "Could not download v${OLD_VERSION}, skipping upgrade test"
+    echo "SKIP: Old version not available for download"
+    exit 0
+}
+
+mkdir -p "${OLD_DIR}"
+tar -xzf "${OLD_TARBALL}" -C "${OLD_DIR}"
+
+# Install old version
+log_info "Installing v${OLD_VERSION}..."
+./${OLD_DIR}/mirror-registry install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+
+# Push test data
+log_info "Pushing test image to old installation..."
+podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+podman pull docker.io/library/busybox 2>/dev/null || true
+podman tag docker.io/library/busybox "${QUAY_ENDPOINT}/init/upgrade-test:v1"
+podman push "${QUAY_ENDPOINT}/init/upgrade-test:v1" --tls-verify=false
+
+# Upgrade to current build
+log_info "Upgrading to current build..."
+${MIRROR_REGISTRY_DIR}/mirror-registry upgrade -v \
+    --quayHostname "${QUAY_ENDPOINT}"
+
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+
+# Verify data preserved — pull the image we pushed before upgrade
+log_info "Verifying data survived upgrade..."
+podman rmi "${QUAY_ENDPOINT}/init/upgrade-test:v1" 2>/dev/null || true
+assert_success "Pull image pushed before upgrade" \
+    podman pull "${QUAY_ENDPOINT}/init/upgrade-test:v1" --tls-verify=false
+
+if podman images | grep -q "upgrade-test"; then
+    log_info "PASS: Image data preserved through SQLite-to-SQLite upgrade"
+    ((PASS_COUNT++))
+else
+    log_error "FAIL: Image data lost during upgrade"
+    ((FAIL_COUNT++))
+fi
+
+# Verify login still works
+assert_success "Login works after upgrade" \
+    podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+
+# Cleanup
+log_info "Uninstalling..."
+${MIRROR_REGISTRY_DIR}/mirror-registry uninstall --autoApprove -v
+rm -rf "${OLD_DIR}" "${OLD_TARBALL}"
+
+print_summary


### PR DESCRIPTION
## Summary
Cherry-picks 6 commits from 2 PRs that were merged to `main` but missing from `mirror-registry-2.0-rhel-8`:

- **PR #263** (5 commits) — Comprehensive e2e test coverage:
  - Go unit tests for `cmd/install.go` and `cmd/utils.go`
  - CI assertion enhancements (health endpoint checks, uninstall verification, custom credentials)
  - GCP VM downsizing to e2-standard-4
  - New `extended-tests.yml` workflow with P0/P1/P2 test scenarios
  - E2e test library (`test/e2e/lib.sh`) and test scripts for: custom TLS, root install, uninstall verification, custom paths, custom hostname, upgrade, reinstall, TLS mismatch, error handling, non-standard port, health endpoint
- **PR #265** (1 commit) — Codecov integration for unit test coverage reporting

## Test plan
- [ ] `pr-check.yml` runs Go unit tests and reports coverage to Codecov
- [ ] `extended-tests.yml` triggers on `ok-to-test` label for PRs targeting `mirror-registry-2.0-rhel-8`
- [ ] All 11 extended test jobs pass on GCP VMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)