### PR TITLE
Revert "fix: set sqlite storage ownership for Quay user after pg-to-sqlite migration (PROJQUAY-9799)"

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/migrate.yaml
@@ -190,21 +190,6 @@
     name: quay-copy
     state: absent
 
-- name: Set ownership of sqlite storage for Quay container user (UID 1001)
-  shell: >-
-    podman unshare chown -R 1001:0
-    "$(podman volume inspect {{ sqlite_storage }} --format '{% raw %}{{ .Mountpoint }}{% endraw %}')"
-  args:
-    executable: /bin/bash
-  when: "not sqlite_storage.startswith('/')"
-
-- name: Set ownership of sqlite storage for Quay container user (UID 1001)
-  shell: >-
-    podman unshare chown -R 1001:0 "{{ expanded_sqlite_storage }}"
-  args:
-    executable: /bin/bash
-  when: "sqlite_storage.startswith('/')"
-
 - name: Copy Quay systemd service file to run quay without migration
   template:
     src: ../templates/quay.service.j2


### PR DESCRIPTION
Reverts quay/mirror-registry#243

Reverting this PR. The `podman unshare chown -R 1001:0` approach has two problems:
1. **Breaks rootful podman** — `podman unshare` only works in rootless mode, failing with `"Error: please use unshare with rootless"` on rootful installs
2. **Hardcodes UID 1001** — some customers run quay-app with a different UID, so chowning to 1001 doesn't fix the issue for them

This is superseded by PR #259 which adds the `,U` flag to the sqlite volume mount in `quay.service.j2`. The `:U` flag tells podman to auto-chown the volume to match whatever UID the container runs as, working correctly for both rootful and rootless podman without hardcoding any UID.
