### PR TITLE
fix: use urlsplit for DB_URI parsing in upgrade (PROJQUAY-7979)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
@@ -23,5 +23,9 @@
 
 - name: Set facts for existing postgres secrets only if they are a string and not a jinja2 variable in the config.yaml.
   ansible.builtin.set_fact:
-    PGDB_PASSWORD : "{{ quay_config_file['DB_URI'].split('@')[0].split(':')[2] }}"
-  when: postgres_container_status.stdout != "" and quay_config_file['DATABASE_SECRET_KEY'] is string and quay_config_file['DB_URI'] is string
+    PGDB_PASSWORD: "{{ quay_config_file['DB_URI'] | urlsplit('password') }}"
+  when: >
+    postgres_container_status.stdout != "" and
+    quay_config_file['DATABASE_SECRET_KEY'] is string and
+    quay_config_file['DB_URI'] is string and
+    (quay_config_file['DB_URI'] | urlsplit('scheme')) == 'postgresql'


### PR DESCRIPTION
## Summary

- Replace brittle `split('@')[0].split(':')[2]` DB_URI parsing with Ansible's `urlsplit` filter in `upgrade-config-vars.yaml`
- Add scheme guard to skip postgres password extraction when `DB_URI` is not a `postgresql://` URI (e.g. after a prior migration changed it to `sqlite:///...`)

## Problem

The upgrade crashes with `"list object has no element 2"` when `DB_URI` in `config.yaml` is not in the expected `postgresql://user:pass@host/db` format. This happens when:
- A prior upgrade already migrated `DB_URI` to sqlite format
- A customer manually edited `config.yaml`
- The password contains special characters like `@` or `:`

## Fix

```diff
-    PGDB_PASSWORD : "{{ quay_config_file['DB_URI'].split('@')[0].split(':')[2] }}"
-  when: postgres_container_status.stdout != "" and quay_config_file['DATABASE_SECRET_KEY'] is string and quay_config_file['DB_URI'] is string
+    PGDB_PASSWORD: "{{ quay_config_file['DB_URI'] | urlsplit('password') }}"
+  when: >
+    postgres_container_status.stdout != "" and
+    quay_config_file['DATABASE_SECRET_KEY'] is string and
+    quay_config_file['DB_URI'] is string and
+    (quay_config_file['DB_URI'] | urlsplit('scheme')) == 'postgresql'
```

## Test plan

- [ ] Upgrade with standard `postgresql://user:password@host/db` DB_URI — `PGDB_PASSWORD` extracted correctly
- [ ] Upgrade with `sqlite:////sqlite/quay_sqlite.db` DB_URI — task skipped, no crash
- [ ] CI postgres-to-sqlite migration test passes (line 418 of jobs.yml)

Resolves: [PROJQUAY-7979](https://redhat.atlassian.net/browse/PROJQUAY-7979)