### PR TITLE
fix: use urlsplit for DB_URI parsing in upgrade (PROJQUAY-7979) [mirror-registry-2.0-rhel-8]

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
@@ -23,5 +23,9 @@
 
 - name: Set facts for existing postgres secrets only if they are a string and not a jinja2 variable in the config.yaml.
   ansible.builtin.set_fact:
-    PGDB_PASSWORD : "{{ quay_config_file['DB_URI'].split('@')[0].split(':')[2] }}"
-  when: postgres_container_status.stdout != "" and quay_config_file['DATABASE_SECRET_KEY'] is string and quay_config_file['DB_URI'] is string
+    PGDB_PASSWORD: "{{ quay_config_file['DB_URI'] | urlsplit('password') }}"
+  when: >
+    postgres_container_status.stdout != "" and
+    quay_config_file['DATABASE_SECRET_KEY'] is string and
+    quay_config_file['DB_URI'] is string and
+    (quay_config_file['DB_URI'] | urlsplit('scheme')) == 'postgresql'


### PR DESCRIPTION
## Summary

Cherry-pick of #273 to `mirror-registry-2.0-rhel-8`.

- Replace brittle `split('@')[0].split(':')[2]` DB_URI parsing with Ansible's `urlsplit` filter in `upgrade-config-vars.yaml`
- Add scheme guard to skip postgres password extraction when `DB_URI` is not a `postgresql://` URI

## Test plan

- [ ] Upgrade with standard `postgresql://` DB_URI — password extracted correctly
- [ ] Upgrade with `sqlite:///` DB_URI — task skipped, no crash

Resolves: [PROJQUAY-7979](https://redhat.atlassian.net/browse/PROJQUAY-7979)