### PR TITLE
fix(ci): skip pulling EE_IMAGE and SQLITE_IMAGE in pull-images job

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -43,7 +43,8 @@ jobs:
         id: images
         run: |
           get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-          for var in QUAY_IMAGE REDIS_IMAGE EE_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE SQLITE_IMAGE; do
+          # Only pull images used as Dockerfile FROM stages
+          for var in QUAY_IMAGE REDIS_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE; do
             ref=$(get_env "$var")
             echo "Pulling $var=$ref"
             docker pull "$ref"
@@ -62,11 +63,9 @@ jobs:
           docker save \
             $(get_env QUAY_IMAGE) \
             $(get_env REDIS_IMAGE) \
-            $(get_env EE_IMAGE) \
             $(get_env EE_BASE_IMAGE) \
             $(get_env EE_BUILDER_IMAGE) \
             $(get_env PAUSE_IMAGE) \
-            $(get_env SQLITE_IMAGE) \
             -o ci-images.tar
 
       - name: Upload images

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -60,7 +60,8 @@ jobs:
         id: images
         run: |
           get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-          for var in QUAY_IMAGE REDIS_IMAGE EE_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE SQLITE_IMAGE; do
+          # Only pull images used as Dockerfile FROM stages
+          for var in QUAY_IMAGE REDIS_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE; do
             ref=$(get_env "$var")
             echo "Pulling $var=$ref"
             docker pull "$ref"
@@ -79,11 +80,9 @@ jobs:
           docker save \
             $(get_env QUAY_IMAGE) \
             $(get_env REDIS_IMAGE) \
-            $(get_env EE_IMAGE) \
             $(get_env EE_BASE_IMAGE) \
             $(get_env EE_BUILDER_IMAGE) \
             $(get_env PAUSE_IMAGE) \
-            $(get_env SQLITE_IMAGE) \
             -o ci-images.tar
 
       - name: Upload images


### PR DESCRIPTION
## Summary
Fixes CI failure introduced by PR #268 where the `pull-images` job tries to `docker pull` all 7 image refs from `.env`, but `EE_IMAGE` (`quay.io/quay/mirror-registry-ee:latest`) is private on quay.io and fails with `unauthorized`.

- `EE_IMAGE` and `SQLITE_IMAGE` are only used as string constants baked into the Go binary via `-ldflags` — they are **not** Dockerfile `FROM` stages
- The `pull-images` job only needs to pull the 5 images actually used in multi-stage builds: `QUAY_IMAGE`, `REDIS_IMAGE`, `EE_BASE_IMAGE`, `EE_BUILDER_IMAGE`, `PAUSE_IMAGE`
- Both refs are still output and passed as `--build-arg` to the build job (as strings, not pulled images)

Fixes both `extended-tests.yml` and `jobs.yml`.

## Test plan
- [ ] `Pull Images` job succeeds without `unauthorized` error
- [ ] `Build Installer` job succeeds with `--network=none` (all FROM stage images pre-loaded)
- [ ] Downstream test jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)