### PR TITLE
ci: pre-load Dockerfile base images and add --network=none to build jobs

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -43,12 +43,15 @@ jobs:
         id: images
         run: |
           get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-          # Only pull images used as Dockerfile FROM stages
+          # Pull images used as Dockerfile FROM stages (from .env)
           for var in QUAY_IMAGE REDIS_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE; do
             ref=$(get_env "$var")
             echo "Pulling $var=$ref"
             docker pull "$ref"
           done
+          # Pull hardcoded Dockerfile FROM base images
+          docker pull registry.access.redhat.com/ubi8:latest
+          docker pull registry.access.redhat.com/ubi8-minimal:latest
           echo "quay=$(get_env QUAY_IMAGE)" >> "$GITHUB_OUTPUT"
           echo "redis=$(get_env REDIS_IMAGE)" >> "$GITHUB_OUTPUT"
           echo "ee=$(get_env EE_IMAGE)" >> "$GITHUB_OUTPUT"
@@ -66,6 +69,8 @@ jobs:
             $(get_env EE_BASE_IMAGE) \
             $(get_env EE_BUILDER_IMAGE) \
             $(get_env PAUSE_IMAGE) \
+            registry.access.redhat.com/ubi8:latest \
+            registry.access.redhat.com/ubi8-minimal:latest \
             -o ci-images.tar
 
       - name: Upload images
@@ -101,6 +106,7 @@ jobs:
       - name: Build offline tarfile
         run: |
           docker build \
+            --network=none \
             -t "mirror-registry-offline:ci" \
             --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
             --build-arg "QUAY_IMAGE=${{ needs.pull-images.outputs.quay-image }}" \

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -60,12 +60,16 @@ jobs:
         id: images
         run: |
           get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-          # Only pull images used as Dockerfile FROM stages
+          # Pull images used as Dockerfile FROM stages (from .env)
           for var in QUAY_IMAGE REDIS_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE; do
             ref=$(get_env "$var")
             echo "Pulling $var=$ref"
             docker pull "$ref"
           done
+          # Pull hardcoded Dockerfile FROM base images
+          docker pull registry.redhat.io/ubi8:latest
+          docker pull registry.access.redhat.com/ubi8:latest
+          docker pull registry.access.redhat.com/ubi8-minimal:latest
           echo "quay=$(get_env QUAY_IMAGE)" >> "$GITHUB_OUTPUT"
           echo "redis=$(get_env REDIS_IMAGE)" >> "$GITHUB_OUTPUT"
           echo "ee=$(get_env EE_IMAGE)" >> "$GITHUB_OUTPUT"
@@ -83,6 +87,9 @@ jobs:
             $(get_env EE_BASE_IMAGE) \
             $(get_env EE_BUILDER_IMAGE) \
             $(get_env PAUSE_IMAGE) \
+            registry.redhat.io/ubi8:latest \
+            registry.access.redhat.com/ubi8:latest \
+            registry.access.redhat.com/ubi8-minimal:latest \
             -o ci-images.tar
 
       - name: Upload images
@@ -154,6 +161,7 @@ jobs:
           IMAGE_NAME="mirror-registry-${INSTALLER_TYPE}:${RELEASE_VERSION}"
 
           docker build \
+            --network=none \
             -t "$IMAGE_NAME" \
             --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
             --build-arg "QUAY_IMAGE=${{ needs.pull-images.outputs.quay-image }}" \


### PR DESCRIPTION
## Summary
- Pre-pull hardcoded Dockerfile `FROM` base images (`ubi8`, `ubi8-minimal`) in the `pull-images` job so they are available for offline `docker build`
- `jobs.yml` also includes `registry.redhat.io/ubi8` for `Dockerfile.online` (auth already covered by existing `docker/login-action`)
- Add `--network=none` to `docker build` in both `build-install-zip` (`jobs.yml`) and `build-installer` (`extended-tests.yml`) to ensure builds run fully offline with pre-loaded images

Fixes the `Build Installer (online)` failure where `FROM registry.redhat.io/ubi8:latest` returned `401 Unauthorized` because the build job has no docker login.

## Test plan
- [ ] `Pull Images` job pulls all base images successfully
- [ ] `Build Installer` (online + offline) passes with `--network=none`
- [ ] `Build Offline Installer` passes with `--network=none`
- [ ] Downstream test jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)