### PR TITLE
ci: remove --network=none from docker build steps

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -106,7 +106,6 @@ jobs:
       - name: Build offline tarfile
         run: |
           docker build \
-            --network=none \
             -t "mirror-registry-offline:ci" \
             --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
             --build-arg "QUAY_IMAGE=${{ needs.pull-images.outputs.quay-image }}" \

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -161,7 +161,6 @@ jobs:
           IMAGE_NAME="mirror-registry-${INSTALLER_TYPE}:${RELEASE_VERSION}"
 
           docker build \
-            --network=none \
             -t "$IMAGE_NAME" \
             --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
             --build-arg "QUAY_IMAGE=${{ needs.pull-images.outputs.quay-image }}" \


### PR DESCRIPTION
## Summary
Remove `--network=none` from `docker build` in both `jobs.yml` and `extended-tests.yml`. The Dockerfiles require network access during build to download Go, Ansible collections, and RPM packages.

Build jobs remain isolated — no secrets, no docker login, no GITHUB_TOKEN.

## Test plan
- [ ] Build Installer (online + offline) passes
- [ ] Build Offline Installer passes
- [ ] Downstream test jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)