### PR TITLE
ci: add SSH keepalive to custom TLS extended test job

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -164,6 +164,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM


### PR DESCRIPTION
## Summary
Add `ServerAliveInterval 30` and `ServerAliveCountMax 10` to the SSH config for the Custom TLS test job in `extended-tests.yml`.

Extended test jobs run the entire test script in a single long SSH session (~8-9 minutes). Without keepalive, the connection drops with `Broken pipe` (exit code 255) before tests complete. Adding this to one job first to verify the fix before applying to all 11.

## Test plan
- [ ] Custom TLS Certificate test passes without `Broken pipe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)