### PR TITLE
fix(test): use except Exception in wait_for_quay health check

### DIFF
--- a/test/e2e/lib.sh
+++ b/test/e2e/lib.sh
@@ -101,8 +101,8 @@ try:
     services = data.get('data', {}).get('services', {})
     if services and all(services.values()):
         sys.exit(0)
-except:
-    pass
+except Exception as e:
+    print(f'Health check error: {e}', file=sys.stderr)
 sys.exit(1)
 " 2>/dev/null; then
             log_info "Quay is healthy after ${elapsed}s"


### PR DESCRIPTION
## Summary
Change `except:` to `except Exception:` in the `wait_for_quay` python health check in `test/e2e/lib.sh`.

`sys.exit(0)` raises `SystemExit` which bare `except:` catches, causing the health check to always report failure even when Quay is healthy. `except Exception:` does not catch `SystemExit`, allowing the successful exit to propagate.

This fixes all 11 extended test jobs which use `wait_for_quay` from `lib.sh`.

## Test plan
- [ ] Extended test jobs pass the `wait_for_quay` health check
- [ ] Verified manually on RHEL VM that the fix resolves the timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)