### PR TITLE
fix: preserve existing secrets on reinstall to prevent Redis auth failure (PROJQUAY-11722)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/create-init-user.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/create-init-user.yaml
@@ -6,4 +6,10 @@
     return_content: yes
     body_format: json
     body: '{ "username": "{{ init_user }}", "password": "{{ init_password }}", "email": "init@quay.io", "access_token": "true" }'
+    status_code: [200, 400]
   register: result
+
+- name: Report init user status
+  debug:
+    msg: "Init user already exists, skipping creation"
+  when: result.status == 400

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
@@ -14,15 +14,29 @@
     existing_quay_config: "{{ existing_config_file['content'] | b64decode | from_yaml }}"
   when: existing_config.stat.exists
 
-- name: Reuse existing secrets from config.yaml
+- name: Reuse existing SECRET_KEY if valid
   ansible.builtin.set_fact:
     secret_key: "{{ existing_quay_config['SECRET_KEY'] }}"
+  when: >
+    existing_config.stat.exists and
+    'SECRET_KEY' in existing_quay_config and
+    existing_quay_config['SECRET_KEY'] is string
+
+- name: Reuse existing DATABASE_SECRET_KEY if valid
+  ansible.builtin.set_fact:
     database_secret_key: "{{ existing_quay_config['DATABASE_SECRET_KEY'] }}"
+  when: >
+    existing_config.stat.exists and
+    'DATABASE_SECRET_KEY' in existing_quay_config and
+    existing_quay_config['DATABASE_SECRET_KEY'] is string
+
+- name: Reuse existing redis_password if valid
+  ansible.builtin.set_fact:
     redis_password: "{{ existing_quay_config['USER_EVENTS_REDIS']['password'] }}"
   when: >
     existing_config.stat.exists and
-    existing_quay_config['SECRET_KEY'] is string and
-    existing_quay_config['DATABASE_SECRET_KEY'] is string and
+    'USER_EVENTS_REDIS' in existing_quay_config and
+    'password' in existing_quay_config['USER_EVENTS_REDIS'] and
     existing_quay_config['USER_EVENTS_REDIS']['password'] is string
 
 - name: Generate secrets for Quay config.yaml

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/secret-vars.yaml
@@ -1,5 +1,32 @@
+- name: Check if config.yaml already exists
+  stat:
+    path: "{{ expanded_quay_root }}/quay-config/config.yaml"
+  register: existing_config
+
+- name: Read existing config.yaml
+  ansible.builtin.slurp:
+    src: "{{ expanded_quay_root }}/quay-config/config.yaml"
+  register: existing_config_file
+  when: existing_config.stat.exists
+
+- name: Parse existing config and preserve secrets
+  ansible.builtin.set_fact:
+    existing_quay_config: "{{ existing_config_file['content'] | b64decode | from_yaml }}"
+  when: existing_config.stat.exists
+
+- name: Reuse existing secrets from config.yaml
+  ansible.builtin.set_fact:
+    secret_key: "{{ existing_quay_config['SECRET_KEY'] }}"
+    database_secret_key: "{{ existing_quay_config['DATABASE_SECRET_KEY'] }}"
+    redis_password: "{{ existing_quay_config['USER_EVENTS_REDIS']['password'] }}"
+  when: >
+    existing_config.stat.exists and
+    existing_quay_config['SECRET_KEY'] is string and
+    existing_quay_config['DATABASE_SECRET_KEY'] is string and
+    existing_quay_config['USER_EVENTS_REDIS']['password'] is string
+
 - name: Generate secrets for Quay config.yaml
   set_fact:
-    secret_key: "{{ lookup('community.general.random_string', length=48, base64=True) }}"
-    database_secret_key: "{{ lookup('community.general.random_string', length=48, base64=True) }}"
-    redis_password: "{{ lookup('community.general.random_string', length=24, special=False) }}"
+    secret_key: "{{ secret_key | default(lookup('community.general.random_string', length=48, base64=True)) }}"
+    database_secret_key: "{{ database_secret_key | default(lookup('community.general.random_string', length=48, base64=True)) }}"
+    redis_password: "{{ redis_password | default(lookup('community.general.random_string', length=24, special=False)) }}"


### PR DESCRIPTION
## Summary

- Preserve existing `redis_password`, `secret_key`, and `database_secret_key` from config.yaml when reinstalling over an existing install (mirrors the approach used in `upgrade-config-vars.yaml`)
- Accept HTTP 400 from init user endpoint on reinstall since the user already exists

## Problem

Running `mirror-registry install` over an existing install (without uninstalling first) causes Quay to crash-loop with `WRONGPASS invalid username-password pair`. The install playbook regenerates random secrets and writes them to config.yaml, but the `redis_pass` podman secret has `skip_existing: true` — so Redis keeps the old password while Quay gets the new one.

A secondary failure occurs at the init user creation step, which returns HTTP 400 (`Cannot initialize user in a non-empty database`) and is treated as a fatal error.

## Test plan

- [x] Fresh install works (no existing config → generates new secrets)
- [x] Reinstall over existing works (secrets preserved, Quay stays healthy)
- [x] `test-idempotent-reinstall.sh` passes end-to-end: install → push image → reinstall → health check → uninstall (2 passed, 0 failed)
- [ ] Upgrade path unaffected (separate playbook, no shared code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)