### PR TITLE
[mirror-registry-2.0-rhel-8] ci: cherry-pick CI workflow and test fixes from main

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -14,13 +14,80 @@ concurrency:
   group: extended-tests
 
 jobs:
+  pull-images:
+    name: "Pull Images"
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    outputs:
+      quay-image: ${{ steps.images.outputs.quay }}
+      redis-image: ${{ steps.images.outputs.redis }}
+      ee-image: ${{ steps.images.outputs.ee }}
+      ee-base-image: ${{ steps.images.outputs.ee_base }}
+      ee-builder-image: ${{ steps.images.outputs.ee_builder }}
+      pause-image: ${{ steps.images.outputs.pause }}
+      sqlite-image: ${{ steps.images.outputs.sqlite }}
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Log into registry.redhat.io
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Resolve and pull images
+        id: images
+        run: |
+          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
+          # Pull images used as Dockerfile FROM stages (from .env)
+          for var in QUAY_IMAGE REDIS_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE; do
+            ref=$(get_env "$var")
+            echo "Pulling $var=$ref"
+            docker pull "$ref"
+          done
+          # Pull hardcoded Dockerfile FROM base images
+          docker pull registry.access.redhat.com/ubi8:latest
+          docker pull registry.access.redhat.com/ubi8-minimal:latest
+          echo "quay=$(get_env QUAY_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "redis=$(get_env REDIS_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "ee=$(get_env EE_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "ee_base=$(get_env EE_BASE_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "ee_builder=$(get_env EE_BUILDER_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "pause=$(get_env PAUSE_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "sqlite=$(get_env SQLITE_IMAGE)" >> "$GITHUB_OUTPUT"
+
+      - name: Save images to tar
+        run: |
+          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
+          docker save \
+            $(get_env QUAY_IMAGE) \
+            $(get_env REDIS_IMAGE) \
+            $(get_env EE_BASE_IMAGE) \
+            $(get_env EE_BUILDER_IMAGE) \
+            $(get_env PAUSE_IMAGE) \
+            registry.access.redhat.com/ubi8:latest \
+            registry.access.redhat.com/ubi8-minimal:latest \
+            -o ci-images.tar
+
+      - name: Upload images
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ci-images
+          path: ci-images.tar
+          retention-days: 1
+
   build-installer:
     name: "Build Offline Installer"
+    needs: [pull-images]
     runs-on: ubuntu-latest
     if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -28,27 +95,26 @@ jobs:
       - name: Set version
         run: echo "RELEASE_VERSION=$GITHUB_REF_NAME" >>"$GITHUB_ENV"
 
-      - name: Log into registry.redhat.io
-        uses: docker/login-action@v2
+      - name: Download images
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          registry: registry.redhat.io
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          name: ci-images
+
+      - name: Load images
+        run: docker load -i ci-images.tar
 
       - name: Build offline tarfile
         run: |
-          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-
           docker build \
             -t "mirror-registry-offline:ci" \
             --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
-            --build-arg "QUAY_IMAGE=$(get_env QUAY_IMAGE)" \
-            --build-arg "EE_IMAGE=$(get_env EE_IMAGE)" \
-            --build-arg "EE_BASE_IMAGE=$(get_env EE_BASE_IMAGE)" \
-            --build-arg "EE_BUILDER_IMAGE=$(get_env EE_BUILDER_IMAGE)" \
-            --build-arg "REDIS_IMAGE=$(get_env REDIS_IMAGE)" \
-            --build-arg "PAUSE_IMAGE=$(get_env PAUSE_IMAGE)" \
-            --build-arg "SQLITE_IMAGE=$(get_env SQLITE_IMAGE)" \
+            --build-arg "QUAY_IMAGE=${{ needs.pull-images.outputs.quay-image }}" \
+            --build-arg "EE_IMAGE=${{ needs.pull-images.outputs.ee-image }}" \
+            --build-arg "EE_BASE_IMAGE=${{ needs.pull-images.outputs.ee-base-image }}" \
+            --build-arg "EE_BUILDER_IMAGE=${{ needs.pull-images.outputs.ee-builder-image }}" \
+            --build-arg "REDIS_IMAGE=${{ needs.pull-images.outputs.redis-image }}" \
+            --build-arg "PAUSE_IMAGE=${{ needs.pull-images.outputs.pause-image }}" \
+            --build-arg "SQLITE_IMAGE=${{ needs.pull-images.outputs.sqlite-image }}" \
             --file Dockerfile .
 
           docker run --name mirror-registry-offline-ci "mirror-registry-offline:ci"
@@ -56,7 +122,7 @@ jobs:
           docker rm mirror-registry-offline-ci
 
       - name: Upload tarfile
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mirror-registry-extended-installer
           path: mirror-registry.tar.gz
@@ -73,10 +139,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -96,6 +164,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -104,12 +174,10 @@ jobs:
           terraform-context: ".github/workflows/extended-tls-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -119,13 +187,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Run custom TLS test
         run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-custom-tls.sh ~'
@@ -147,10 +216,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -170,6 +241,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -178,12 +251,10 @@ jobs:
           terraform-context: ".github/workflows/extended-root-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -193,19 +264,33 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
+      - name: Configure root SSH access
         run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+          ssh ci-user@quay 'sudo bash -euo pipefail -c "
+            sed -i \"s/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/\" /etc/ssh/sshd_config
+            systemctl restart sshd
+            install -d -m 700 /root/.ssh
+            ssh-keygen -t ed25519 -f /root/.ssh/id_rsa -N \"\" -q
+            cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+            chmod 600 /root/.ssh/authorized_keys /root/.ssh/id_rsa
+            echo -e \"Host *\n  StrictHostKeyChecking no\" > /root/.ssh/config
+            chmod 600 /root/.ssh/config
+          "'
+
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
 
       - name: Run root install test
-        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-root-install.sh ~'
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay sudo bash ~/e2e/test-root-install.sh ~'
 
       - name: Terraform Destroy
         run: terraform destroy --auto-approve
@@ -224,10 +309,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -247,6 +334,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -255,12 +344,10 @@ jobs:
           terraform-context: ".github/workflows/extended-uninstall-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -270,13 +357,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -301,10 +389,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -324,6 +414,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -332,12 +424,10 @@ jobs:
           terraform-context: ".github/workflows/extended-paths-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -347,13 +437,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -378,10 +469,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -401,6 +494,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -409,12 +504,10 @@ jobs:
           terraform-context: ".github/workflows/extended-hostname-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -424,13 +517,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -455,10 +549,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -478,6 +574,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -486,12 +584,10 @@ jobs:
           terraform-context: ".github/workflows/extended-upgrade-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -501,13 +597,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -532,10 +629,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -555,6 +654,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -563,12 +664,10 @@ jobs:
           terraform-context: ".github/workflows/extended-reinstall-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -578,13 +677,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -609,10 +709,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -632,6 +734,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -640,12 +744,10 @@ jobs:
           terraform-context: ".github/workflows/extended-tls-mismatch-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -655,13 +757,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Run TLS mismatch test
         run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-tls-mismatch.sh ~'
@@ -683,10 +786,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -706,6 +811,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -714,12 +821,10 @@ jobs:
           terraform-context: ".github/workflows/extended-errors-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -729,13 +834,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Run invalid cert error test
         run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-error-invalid-cert.sh ~'
@@ -763,10 +869,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -786,6 +894,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -794,12 +904,10 @@ jobs:
           terraform-context: ".github/workflows/extended-port-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -809,13 +917,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Pull busybox for push/pull test
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -840,10 +949,12 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_wrapper: false
@@ -863,6 +974,8 @@ jobs:
             User ci-user
             IdentityFile ~/.ssh/staging.key
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
           END
 
       - name: Initialize VM
@@ -871,12 +984,10 @@ jobs:
           terraform-context: ".github/workflows/extended-health-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-extended-installer
 
@@ -886,13 +997,14 @@ jobs:
       - name: Install podman
         run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
 
-      - name: SCP tarball and test scripts to VM
-        run: |
-          scp mirror-registry.tar.gz ci-user@quay:~/
-          scp -r test/e2e ci-user@quay:~/e2e
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
 
       - name: Extract tarball
         run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
 
       - name: Run health endpoint test
         run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-health-endpoint.sh ~'

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -23,32 +23,110 @@ concurrency:
   group: limit-to-one
 
 jobs:
-  build-install-zip:
-    name: "Build Installer"
+  pull-images:
+    name: "Pull Images"
     runs-on: ubuntu-latest
     if: github.repository_owner == 'quay' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ok-to-test') || github.event.inputs.version)
     outputs:
       quay-image: ${{ steps.images.outputs.quay }}
       redis-image: ${{ steps.images.outputs.redis }}
+      ee-image: ${{ steps.images.outputs.ee }}
+      ee-base-image: ${{ steps.images.outputs.ee_base }}
+      ee-builder-image: ${{ steps.images.outputs.ee_builder }}
+      pause-image: ${{ steps.images.outputs.pause }}
+      sqlite-image: ${{ steps.images.outputs.sqlite }}
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: "!github.event.inputs.version"
+        with:
+          persist-credentials: false
+
+      - name: Checkout release tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: github.event.inputs.version
+        with:
+          ref: refs/tags/${{ github.event.inputs.version }}
+          persist-credentials: false
+
+      - name: Log into docker for registry.redhat.io
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Resolve and pull images
+        id: images
+        run: |
+          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
+          # Pull images used as Dockerfile FROM stages (from .env)
+          for var in QUAY_IMAGE REDIS_IMAGE EE_BASE_IMAGE EE_BUILDER_IMAGE PAUSE_IMAGE; do
+            ref=$(get_env "$var")
+            echo "Pulling $var=$ref"
+            docker pull "$ref"
+          done
+          # Pull hardcoded Dockerfile FROM base images
+          docker pull registry.redhat.io/ubi8:latest
+          docker pull registry.access.redhat.com/ubi8:latest
+          docker pull registry.access.redhat.com/ubi8-minimal:latest
+          echo "quay=$(get_env QUAY_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "redis=$(get_env REDIS_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "ee=$(get_env EE_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "ee_base=$(get_env EE_BASE_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "ee_builder=$(get_env EE_BUILDER_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "pause=$(get_env PAUSE_IMAGE)" >> "$GITHUB_OUTPUT"
+          echo "sqlite=$(get_env SQLITE_IMAGE)" >> "$GITHUB_OUTPUT"
+
+      - name: Save images to tar
+        run: |
+          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
+          docker save \
+            $(get_env QUAY_IMAGE) \
+            $(get_env REDIS_IMAGE) \
+            $(get_env EE_BASE_IMAGE) \
+            $(get_env EE_BUILDER_IMAGE) \
+            $(get_env PAUSE_IMAGE) \
+            registry.redhat.io/ubi8:latest \
+            registry.access.redhat.com/ubi8:latest \
+            registry.access.redhat.com/ubi8-minimal:latest \
+            -o ci-images.tar
+
+      - name: Upload images
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ci-images
+          path: ci-images.tar
+          retention-days: 1
+
+  build-install-zip:
+    name: "Build Installer"
+    needs: [pull-images]
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'quay' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ok-to-test') || github.event.inputs.version)
     strategy:
       matrix:
         installer-type: ["online", "offline"]
     steps:
-      # Checkout source branch for testing
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      # Checkout target branch for release build
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout base branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: github.event_name == 'push'
+        with:
+          persist-credentials: false
+
+      - name: Checkout release tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: github.event.inputs.version
         with:
           ref: refs/tags/${{ github.event.inputs.version }}
           persist-credentials: false
-        if: github.event.inputs.version
 
       - name: Set version from tag/branch
         run: |
@@ -62,24 +140,16 @@ jobs:
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
 
-      - name: Log into docker for registry.redhat.io
-        uses: docker/login-action@v2
+      - name: Download images
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          registry: registry.redhat.io
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          name: ci-images
 
-      - name: Resolve image refs
-        id: images
-        run: |
-          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-          echo "quay=$(get_env QUAY_IMAGE)" >> "$GITHUB_OUTPUT"
-          echo "redis=$(get_env REDIS_IMAGE)" >> "$GITHUB_OUTPUT"
+      - name: Load images
+        run: docker load -i ci-images.tar
 
       - name: Build tarfile
         run: |
-          get_env() { grep "^$1=" .env | head -1 | cut -d= -f2-; }
-
           INSTALLER_TYPE="${{ matrix.installer-type }}"
           if [ "$INSTALLER_TYPE" = "offline" ]; then
             DOCKERFILE="Dockerfile"
@@ -93,13 +163,13 @@ jobs:
           docker build \
             -t "$IMAGE_NAME" \
             --build-arg "RELEASE_VERSION=${RELEASE_VERSION}" \
-            --build-arg "QUAY_IMAGE=$(get_env QUAY_IMAGE)" \
-            --build-arg "EE_IMAGE=$(get_env EE_IMAGE)" \
-            --build-arg "EE_BASE_IMAGE=$(get_env EE_BASE_IMAGE)" \
-            --build-arg "EE_BUILDER_IMAGE=$(get_env EE_BUILDER_IMAGE)" \
-            --build-arg "REDIS_IMAGE=$(get_env REDIS_IMAGE)" \
-            --build-arg "PAUSE_IMAGE=$(get_env PAUSE_IMAGE)" \
-            --build-arg "SQLITE_IMAGE=$(get_env SQLITE_IMAGE)" \
+            --build-arg "QUAY_IMAGE=${{ needs.pull-images.outputs.quay-image }}" \
+            --build-arg "EE_IMAGE=${{ needs.pull-images.outputs.ee-image }}" \
+            --build-arg "EE_BASE_IMAGE=${{ needs.pull-images.outputs.ee-base-image }}" \
+            --build-arg "EE_BUILDER_IMAGE=${{ needs.pull-images.outputs.ee-builder-image }}" \
+            --build-arg "REDIS_IMAGE=${{ needs.pull-images.outputs.redis-image }}" \
+            --build-arg "PAUSE_IMAGE=${{ needs.pull-images.outputs.pause-image }}" \
+            --build-arg "SQLITE_IMAGE=${{ needs.pull-images.outputs.sqlite-image }}" \
             --file "$DOCKERFILE" .
 
           docker run --name "$CONTAINER_NAME" "$IMAGE_NAME"
@@ -107,7 +177,7 @@ jobs:
           docker rm "$CONTAINER_NAME"
 
       - name: Upload tarfile
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mirror-registry-${{ matrix.installer-type }}-installer
           path: mirror-registry.tar.gz
@@ -118,7 +188,7 @@ jobs:
     # receives the deployment, matching the real-world remote install topology
     # where an operator machine deploys to a separate target host.
     name: "Remote Install"
-    needs: ["build-install-zip"]
+    needs: ["build-install-zip", "pull-images"]
     runs-on: ubuntu-latest
     environment: ci-testing
     timeout-minutes: 60
@@ -131,15 +201,17 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
+        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
         with:
           oc_version: "4.6"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -179,12 +251,10 @@ jobs:
         working-directory: ".github/workflows/remote-${{ matrix.installer-type }}-installer"
 
       - name: Wait for VMs
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-${{ matrix.installer-type }}-installer
 
@@ -204,8 +274,8 @@ jobs:
         env:
           REGISTRY_USER: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASS: ${{ secrets.REGISTRY_PASSWORD }}
-          QUAY_IMG: ${{ needs.build-install-zip.outputs.quay-image }}
-          REDIS_IMG: ${{ needs.build-install-zip.outputs.redis-image }}
+          QUAY_IMG: ${{ needs.pull-images.outputs.quay-image }}
+          REDIS_IMG: ${{ needs.pull-images.outputs.redis-image }}
 
       - name: Install podman on control VM
         run: ssh ci-user@control 'sudo subscription-manager refresh; sudo yum -y install podman'
@@ -310,7 +380,7 @@ jobs:
 
   test-local-install:
     name: "Local Install"
-    needs: ["build-install-zip"]
+    needs: ["build-install-zip", "pull-images"]
     runs-on: ubuntu-latest
     environment: ci-testing
     timeout-minutes: 60
@@ -323,15 +393,17 @@ jobs:
       GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@v1
+        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
         with:
           oc_version: "4.6"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
         with:
           # terraform_version: 0.13.0:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -360,12 +432,10 @@ jobs:
           terraform-context: ".github/workflows/local-${{ matrix.installer-type }}-installer"
 
       - name: Wait for VM
-        uses: jakejarvis/wait-action@master
-        with:
-          time: "60s"
+        run: sleep 60
 
       - name: Download tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-${{ matrix.installer-type }}-installer
 
@@ -388,8 +458,8 @@ jobs:
         env:
           REGISTRY_USER: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASS: ${{ secrets.REGISTRY_PASSWORD }}
-          QUAY_IMG: ${{ needs.build-install-zip.outputs.quay-image }}
-          REDIS_IMG: ${{ needs.build-install-zip.outputs.redis-image }}
+          QUAY_IMG: ${{ needs.pull-images.outputs.quay-image }}
+          REDIS_IMG: ${{ needs.pull-images.outputs.redis-image }}
 
       - name: Pull busybox image from Docker Hub before disabling traffic
         run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
@@ -503,24 +573,26 @@ jobs:
     if: github.repository_owner == 'quay' && (github.event_name == 'push' || github.event.inputs.version)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Download offline tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-offline-installer
       - name: Rename offline tarfile
         run: mv mirror-registry.tar.gz mirror-registry-offline.tar.gz
 
       - name: Download online tarfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: mirror-registry-online-installer
 
       - name: Rename online tarfile
         run: mv mirror-registry.tar.gz mirror-registry-online.tar.gz
 
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "*.tar.gz,README.md"
           allowUpdates: true
@@ -528,7 +600,7 @@ jobs:
           tag: ${{ github.ref_name }}
         if: github.event_name == 'push'
 
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "*.tar.gz,README.md"
           allowUpdates: true

--- a/test/e2e/test-auto-password.sh
+++ b/test/e2e/test-auto-password.sh
@@ -22,32 +22,32 @@ wait_for_quay "${QUAY_ENDPOINT}"
 # Format: "Quay is available at https://host:8443 with credentials (init, <password>)"
 if echo "${install_output}" | grep -q "credentials (init,"; then
     log_info "PASS: Install output contains generated credentials"
-    ((PASS_COUNT++))
+    (( ++PASS_COUNT ))
 
     # Extract the password from output
-    generated_password=$(echo "${install_output}" | grep "credentials (init," | sed 's/.*credentials (init, \(.*\))/\1/' | tr -d ')')
+    generated_password=$(echo "${install_output}" | grep "credentials (init," | sed 's/.*credentials (init, \([^)]*\)).*/\1/')
     log_info "Generated password length: ${#generated_password}"
 
     if [[ ${#generated_password} -gt 8 ]]; then
         log_info "PASS: Generated password has sufficient length"
-        ((PASS_COUNT++))
+        (( ++PASS_COUNT ))
     else
         log_error "FAIL: Generated password too short: ${#generated_password} chars"
-        ((FAIL_COUNT++))
+        (( ++FAIL_COUNT ))
     fi
 
     # Verify we can login with the generated password
     if podman login -u init -p "${generated_password}" "${QUAY_ENDPOINT}" --tls-verify=false 2>/dev/null; then
         log_info "PASS: Login succeeded with generated password"
-        ((PASS_COUNT++))
+        (( ++PASS_COUNT ))
     else
         log_error "FAIL: Login failed with generated password"
-        ((FAIL_COUNT++))
+        (( ++FAIL_COUNT ))
     fi
 else
     log_error "FAIL: Install output does not contain generated credentials"
     log_error "  Output: ${install_output}"
-    ((FAIL_COUNT++))
+    (( ++FAIL_COUNT ))
 fi
 
 # Cleanup

--- a/test/e2e/test-custom-hostname.sh
+++ b/test/e2e/test-custom-hostname.sh
@@ -30,7 +30,7 @@ wait_for_quay "${CUSTOM_ENDPOINT}"
 assert_quay_healthy "${CUSTOM_ENDPOINT}"
 
 # Verify config.yaml has the custom hostname
-config_hostname=$(grep "SERVER_HOSTNAME" ~/quay-install/quay-config/config.yaml 2>/dev/null | head -1 || echo "")
+config_hostname=$(grep "^SERVER_HOSTNAME:" ~/quay-install/quay-config/config.yaml 2>/dev/null | head -1 || echo "")
 assert_contains "SERVER_HOSTNAME set to custom hostname" "${config_hostname}" "${CUSTOM_ENDPOINT}"
 
 # Verify Quay is accessible at custom hostname

--- a/test/e2e/test-custom-tls.sh
+++ b/test/e2e/test-custom-tls.sh
@@ -36,17 +36,17 @@ provided_serial=$(openssl x509 -in "${CERT_DIR}/server.cert" -noout -serial 2>/d
 
 if [[ "${server_serial}" == "${provided_serial}" ]]; then
     log_info "PASS: Server is using the provided certificate"
-    ((PASS_COUNT++))
+    (( ++PASS_COUNT ))
 else
     log_error "FAIL: Server certificate does not match provided cert"
     log_error "  Server serial:   ${server_serial}"
     log_error "  Provided serial: ${provided_serial}"
-    ((FAIL_COUNT++))
+    (( ++FAIL_COUNT ))
 fi
 
 # Verify we can login using the CA to trust the cert
 log_info "Verifying podman login with CA trust..."
-mkdir -p "/etc/containers/certs.d/${QUAY_ENDPOINT}"
+sudo mkdir -p "/etc/containers/certs.d/${QUAY_ENDPOINT}"
 cp "${CERT_DIR}/ca.pem" "/etc/containers/certs.d/${QUAY_ENDPOINT}/ca.crt" 2>/dev/null || \
     sudo cp "${CERT_DIR}/ca.pem" "/etc/containers/certs.d/${QUAY_ENDPOINT}/ca.crt"
 

--- a/test/e2e/test-tls-mismatch.sh
+++ b/test/e2e/test-tls-mismatch.sh
@@ -28,35 +28,34 @@ if ${MIRROR_REGISTRY} install -v \
     --sslCert "${CERT_DIR}/server.cert" \
     --sslKey "${CERT_DIR}/server.key" 2>&1; then
     log_error "FAIL: Install should have rejected mismatched certificate"
-    ((FAIL_COUNT++))
+    (( ++FAIL_COUNT ))
     # Clean up if it somehow installed
     ${MIRROR_REGISTRY} uninstall --autoApprove -v 2>/dev/null || true
 else
     log_info "PASS: Install correctly rejected mismatched certificate"
-    ((PASS_COUNT++))
+    (( ++PASS_COUNT ))
 fi
 
-# Now install with --sslCheckSkip — should succeed
-log_info "Installing with --sslCheckSkip (should succeed)..."
-${MIRROR_REGISTRY} install -v \
+# Now install with --sslCheckSkip — should bypass CLI cert validation
+log_info "Installing with --sslCheckSkip (should bypass CLI cert check)..."
+sslskip_output=$(${MIRROR_REGISTRY} install -v \
     --quayHostname "${QUAY_ENDPOINT}" \
     --initPassword password \
     --sslCert "${CERT_DIR}/server.cert" \
     --sslKey "${CERT_DIR}/server.key" \
-    --sslCheckSkip
+    --sslCheckSkip 2>&1) || true
 
-wait_for_quay "${QUAY_ENDPOINT}"
-assert_quay_healthy "${QUAY_ENDPOINT}"
-log_info "PASS: Install succeeded with --sslCheckSkip"
-((PASS_COUNT++))
-
-# Verify we can still login (using tls-verify=false since cert is for wrong host)
-assert_success "Login works with --sslCheckSkip install" \
-    podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+if echo "${sslskip_output}" | grep -q "Failed verifying certificate"; then
+    log_error "FAIL: --sslCheckSkip did not bypass CLI cert validation"
+    (( ++FAIL_COUNT ))
+else
+    log_info "PASS: --sslCheckSkip bypassed CLI cert validation"
+    (( ++PASS_COUNT ))
+fi
 
 # Cleanup
 log_info "Uninstalling..."
-${MIRROR_REGISTRY} uninstall --autoApprove -v
+${MIRROR_REGISTRY} uninstall --autoApprove -v 2>/dev/null || true
 rm -rf "${CERT_DIR}"
 
 print_summary


### PR DESCRIPTION
## Summary

Cherry-pick CI workflow and test script fixes from main that were missing on the release branch.

**PRs included:**
- #277 — ci: pre-load Dockerfile base images and add --network=none to build jobs
- #278 — ci: remove --network=none from docker build steps
- #275 — fix(ci): skip pulling EE_IMAGE and SQLITE_IMAGE in pull-images job
- #279 — ci: add SSH keepalive to custom TLS test job
- #281 — fix(test): add SSH keepalive to all extended test jobs and fix mkdir permission
- #282 — fix(test): resolve extended test failures for custom-hostname, auto-password, tls-mismatch, and root-install

**What changed:**
- `jobs.yml` and `extended-tests.yml` synced from main (adds pull-images job, SHA-pinned actions, SSH keepalive, artifact v4)
- Test scripts fixed: `test-custom-tls.sh`, `test-auto-password.sh`, `test-custom-hostname.sh`, `test-tls-mismatch.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)