### PR TITLE
fix: preserve existing hostname and storage paths during upgrade (PROJQUAY-11690)

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -938,6 +938,86 @@ jobs:
         working-directory: ".github/workflows/extended-port-installer"
         if: always()
 
+  test-upgrade-preserves-config:
+    name: "Upgrade Preserves Config"
+    needs: [build-installer]
+    runs-on: ubuntu-latest
+    environment: ci-testing
+    timeout-minutes: 60
+    if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    env:
+      GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Generate SSH key pair
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_rsa -N "" -C "ci-run-${{ github.run_id }}"
+          echo "TF_VAR_SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        run: |
+          cp ~/.ssh/id_rsa ~/.ssh/staging.key
+          chmod 600 ~/.ssh/staging.key
+          cat >>~/.ssh/config <<END
+          Host quay
+            HostName quay
+            User ci-user
+            IdentityFile ~/.ssh/staging.key
+            StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 10
+          END
+
+      - name: Initialize VM
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform-context: ".github/workflows/extended-port-installer"
+
+      - name: Wait for VM
+        run: sleep 60
+
+      - name: Download tarfile
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: mirror-registry-extended-installer
+
+      - name: Add quay to /etc/hosts
+        run: ssh ci-user@quay 'echo "127.0.0.1 quay" | sudo tee -a /etc/hosts'
+
+      - name: Install podman
+        run: ssh ci-user@quay 'sudo subscription-manager refresh; sudo yum -y install podman'
+
+      - name: SCP tarball to VM
+        run: scp mirror-registry.tar.gz ci-user@quay:~/
+
+      - name: Extract tarball
+        run: ssh ci-user@quay 'tar -xf mirror-registry.tar.gz'
+
+      - name: SCP test scripts to VM
+        run: scp -r test/e2e ci-user@quay:~/e2e
+
+      - name: Pull busybox for push/pull test
+        run: ssh ci-user@quay 'podman pull docker.io/library/busybox'
+
+      - name: Run upgrade config preservation test
+        run: ssh ci-user@quay 'QUAY_HOSTNAME=quay bash ~/e2e/test-upgrade-preserves-config.sh ~'
+
+      - name: Terraform Destroy
+        run: terraform destroy --auto-approve
+        shell: bash
+        working-directory: ".github/workflows/extended-port-installer"
+        if: always()
+
   test-health-endpoint:
     name: "Health Endpoint Validation"
     needs: [build-installer]

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
@@ -29,3 +29,31 @@
     quay_config_file['DATABASE_SECRET_KEY'] is string and
     quay_config_file['DB_URI'] is string and
     (quay_config_file['DB_URI'] | urlsplit('scheme')) == 'postgresql'
+
+- name: Use existing SERVER_HOSTNAME if --quayHostname was not explicitly set
+  ansible.builtin.set_fact:
+    quay_hostname: "{{ quay_config_file['SERVER_HOSTNAME'] }}"
+  when: >
+    quay_hostname_explicit | default('true') | lower != 'true' and
+    'SERVER_HOSTNAME' in quay_config_file and
+    quay_config_file['SERVER_HOSTNAME'] is string
+
+- name: Read existing quay-app.service for storage paths
+  ansible.builtin.slurp:
+    src: "{{ systemd_unit_dir }}/quay-app.service"
+  register: existing_quay_service_file
+  ignore_errors: yes
+
+- name: Use existing quay_storage if --quayStorage was not explicitly set
+  ansible.builtin.set_fact:
+    quay_storage: "{{ (existing_quay_service_file.content | b64decode) | regex_search('-v\\s+(\\S+):/datastorage', '\\1') | default([quay_storage], true) | first }}"
+  when: >
+    quay_storage_explicit | default('true') | lower != 'true' and
+    existing_quay_service_file is succeeded
+
+- name: Use existing sqlite_storage if --sqliteStorage was not explicitly set
+  ansible.builtin.set_fact:
+    sqlite_storage: "{{ (existing_quay_service_file.content | b64decode) | regex_search('-v\\s+(\\S+):/sqlite', '\\1') | default([sqlite_storage], true) | first }}"
+  when: >
+    sqlite_storage_explicit | default('true') | lower != 'true' and
+    existing_quay_service_file is succeeded

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
@@ -13,6 +13,9 @@
 - name: Autodetect existing Secrets in config.yaml
   include_tasks: upgrade-config-vars.yaml
 
+- name: Re-expand variables after config overrides
+  include_tasks: expand-vars.yaml
+
 - name: Validate SSL Certificates
   include_tasks: validate-ssl-certs.yaml
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -18,8 +18,8 @@ import (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade all mirror registry images.",
-	Run: func(cmd *cobra.Command, args []string) {
-		upgrade()
+	Run: func(cobraCmd *cobra.Command, args []string) {
+		upgrade(cobraCmd)
 	},
 }
 
@@ -47,7 +47,7 @@ func init() {
 
 }
 
-func upgrade() {
+func upgrade(cobraCmd *cobra.Command) {
 
 	var err error
 	log.Printf("Upgrade has begun")
@@ -57,6 +57,11 @@ func upgrade() {
 	log.Debug("Quay Image: " + quayImage)
 	log.Debug("Redis Image: " + redisImage)
 
+	// Detect which flags the user explicitly passed
+	quayHostnameExplicit := cobraCmd.Flags().Changed("quayHostname")
+	quayStorageExplicit := cobraCmd.Flags().Changed("quayStorage")
+	sqliteStorageExplicit := cobraCmd.Flags().Changed("sqliteStorage")
+
 	// Load execution environment
 	err = loadExecutionEnvironment()
 	check(err)
@@ -64,6 +69,9 @@ func upgrade() {
 	// Set quayHostname if not already set
 	if quayHostname == "" {
 		quayHostname = targetHostname + ":8443"
+	}
+	if !strings.Contains(quayHostname, ":") {
+		quayHostname = quayHostname + ":8443"
 	}
 
 	// Load the SSL certificate and the key
@@ -161,16 +169,6 @@ func upgrade() {
 		}
 	}
 
-	// Set quayHostname if not already set
-	if quayHostname == "" {
-		quayHostname = targetHostname + ":8443"
-	}
-
-	// Add port if not present
-	if !strings.Contains(quayHostname, ":") {
-		quayHostname = quayHostname + ":8443"
-	}
-
 	// Set askBecomePass flag if true
 	var askBecomePassFlag string
 	if askBecomePass {
@@ -210,8 +208,8 @@ func upgrade() {
 		`--quiet `+
 		`--name ansible_runner_instance `+
 		fmt.Sprintf("%s ", eeImage)+
-		`ansible-playbook -i %s@%s, --private-key /runner/env/ssh_key -e "quay_image=%s quay_version=%s redis_image=%s sqlite_image=%s pause_image=%s quay_hostname=%s local_install=%s quay_root=%s quay_storage=%s sqlite_storage=%s" upgrade_mirror_appliance.yml %s %s`,
-		sshKey, targetUsername, targetHostname, quayImage, quayVersion, redisImage, sqliteImage, pauseImage, quayHostname, strconv.FormatBool(isLocalInstall()), quayRoot, quayStorage, sqliteStorage, askBecomePassFlag, additionalArgs)
+		`ansible-playbook -i %s@%s, --private-key /runner/env/ssh_key -e "quay_image=%s quay_version=%s redis_image=%s sqlite_image=%s pause_image=%s quay_hostname=%s quay_hostname_explicit=%s local_install=%s quay_root=%s quay_storage=%s quay_storage_explicit=%s sqlite_storage=%s sqlite_storage_explicit=%s" upgrade_mirror_appliance.yml %s %s`,
+		sshKey, targetUsername, targetHostname, quayImage, quayVersion, redisImage, sqliteImage, pauseImage, quayHostname, strconv.FormatBool(quayHostnameExplicit), strconv.FormatBool(isLocalInstall()), quayRoot, quayStorage, strconv.FormatBool(quayStorageExplicit), sqliteStorage, strconv.FormatBool(sqliteStorageExplicit), askBecomePassFlag, additionalArgs)
 
 	log.Debug("Running command: " + podmanCmd)
 	cmd := exec.Command("bash", "-c", podmanCmd)

--- a/test/e2e/lib.sh
+++ b/test/e2e/lib.sh
@@ -267,7 +267,7 @@ verify_push_pull() {
     podman rmi "${hostname}/${username}/busybox:test" 2>/dev/null || true
     podman pull "${hostname}/${username}/busybox:test" ${tls_verify}
 
-    if podman images | grep -q "${hostname}/${username}/busybox"; then
+    if podman images --no-trunc --format '{{.Repository}}:{{.Tag}}' | grep -q "${hostname}/${username}/busybox"; then
         log_info "PASS: Push/pull verification"
         (( ++PASS_COUNT ))
     else

--- a/test/e2e/test-upgrade-preserves-config.sh
+++ b/test/e2e/test-upgrade-preserves-config.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Test that upgrade preserves existing hostname/port and storage paths
+# when flags are not explicitly re-passed.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+MIRROR_REGISTRY="${1:-.}/mirror-registry"
+HOSTNAME="${QUAY_HOSTNAME:-$(hostname -f)}"
+CUSTOM_PORT="9443"
+QUAY_ENDPOINT="${HOSTNAME}:${CUSTOM_PORT}"
+
+log_info "=== Test: Upgrade Preserves Existing Config ==="
+
+# Install with custom port
+log_info "Installing with custom port ${CUSTOM_PORT}..."
+${MIRROR_REGISTRY} install -v \
+    --quayHostname "${QUAY_ENDPOINT}" \
+    --initPassword password
+
+wait_for_quay "${QUAY_ENDPOINT}"
+
+# Record pre-upgrade state
+pre_hostname=$(grep SERVER_HOSTNAME ~/quay-install/quay-config/config.yaml | awk '{print $2}')
+log_info "Pre-upgrade SERVER_HOSTNAME: ${pre_hostname}"
+
+# Push test image
+podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
+podman pull docker.io/library/busybox 2>/dev/null || true
+podman tag docker.io/library/busybox "${QUAY_ENDPOINT}/init/config-test:v1"
+podman push "${QUAY_ENDPOINT}/init/config-test:v1" --tls-verify=false
+
+# Upgrade WITHOUT passing --quayHostname (the bug scenario)
+log_info "Upgrading without --quayHostname flag..."
+${MIRROR_REGISTRY} upgrade -v
+
+# Verify port preserved
+wait_for_quay "${QUAY_ENDPOINT}"
+assert_quay_healthy "${QUAY_ENDPOINT}"
+
+if ss -tlnp 2>/dev/null | grep -q ":${CUSTOM_PORT} "; then
+    log_info "PASS: Custom port ${CUSTOM_PORT} preserved after upgrade"
+    (( ++PASS_COUNT ))
+else
+    log_error "FAIL: Custom port ${CUSTOM_PORT} not listening after upgrade"
+    (( ++FAIL_COUNT ))
+fi
+
+# Verify SERVER_HOSTNAME preserved in config.yaml
+post_hostname=$(grep SERVER_HOSTNAME ~/quay-install/quay-config/config.yaml | awk '{print $2}')
+if [[ "${pre_hostname}" == "${post_hostname}" ]]; then
+    log_info "PASS: SERVER_HOSTNAME preserved (${post_hostname})"
+    (( ++PASS_COUNT ))
+else
+    log_error "FAIL: SERVER_HOSTNAME changed from ${pre_hostname} to ${post_hostname}"
+    (( ++FAIL_COUNT ))
+fi
+
+# Verify data survived
+podman rmi "${QUAY_ENDPOINT}/init/config-test:v1" 2>/dev/null || true
+assert_success "Pull image after upgrade" \
+    podman pull "${QUAY_ENDPOINT}/init/config-test:v1" --tls-verify=false
+
+# Cleanup
+${MIRROR_REGISTRY} uninstall --autoApprove -v
+
+print_summary

--- a/test/e2e/test-upgrade-sqlite.sh
+++ b/test/e2e/test-upgrade-sqlite.sh
@@ -49,8 +49,7 @@ podman push "${QUAY_ENDPOINT}/init/upgrade-test:v1" --tls-verify=false
 
 # Upgrade to current build
 log_info "Upgrading to current build..."
-${MIRROR_REGISTRY_DIR}/mirror-registry upgrade -v \
-    --quayHostname "${QUAY_ENDPOINT}"
+${MIRROR_REGISTRY_DIR}/mirror-registry upgrade -v
 
 wait_for_quay "${QUAY_ENDPOINT}"
 assert_quay_healthy "${QUAY_ENDPOINT}"
@@ -61,7 +60,7 @@ podman rmi "${QUAY_ENDPOINT}/init/upgrade-test:v1" 2>/dev/null || true
 assert_success "Pull image pushed before upgrade" \
     podman pull "${QUAY_ENDPOINT}/init/upgrade-test:v1" --tls-verify=false
 
-if podman images | grep -q "upgrade-test"; then
+if podman images --no-trunc --format '{{.Repository}}:{{.Tag}}' | grep -q "upgrade-test"; then
     log_info "PASS: Image data preserved through SQLite-to-SQLite upgrade"
     (( ++PASS_COUNT ))
 else


### PR DESCRIPTION
## Summary

- Read `SERVER_HOSTNAME` from existing `config.yaml` during upgrade and use it as the default for `quay_hostname` when `--quayHostname` is not explicitly passed
- Read existing `quay_storage` and `sqlite_storage` paths from the running `quay-app.service` systemd unit and preserve them when not explicitly overridden
- Add `Flags().Changed()` detection in Go CLI to distinguish "user passed this flag" from "using the default"
- Add e2e test for the exact customer scenario (install on port 9443, upgrade without flags)

## Problem

When a customer installs with `--quayHostname registry:9443` and later runs `./mirror-registry upgrade` without re-passing that flag, the Go CLI defaults to `<hostname>:8443`. The pod gets recreated on port 8443, breaking connectivity. Same issue exists for custom `--quayStorage` and `--sqliteStorage` paths.

## How it works

1. **Go CLI** (`cmd/upgrade.go`): Uses `cobra.Command.Flags().Changed()` to detect which flags were explicitly set. Passes `quay_hostname_explicit`, `quay_storage_explicit`, `sqlite_storage_explicit` booleans to Ansible.

2. **Ansible** (`upgrade-config-vars.yaml`): After reading config.yaml (existing logic for Redis/Postgres secrets), conditionally overrides `quay_hostname` from `SERVER_HOSTNAME` and storage paths from the existing systemd service file — only when the corresponding `*_explicit` flag is `false`.

3. **Ansible** (`upgrade.yaml`): Re-runs `expand-vars.yaml` after the overrides so `expanded_*` variables reflect the correct values before templates are rendered.

## Backward compatibility

- Old Go binary + new Ansible: `*_explicit` defaults to `"true"` via `| default('true')` — identical to current behavior
- New Go binary + old Ansible: extra vars silently ignored — no breakage
- Explicit flags always win

## Test plan

- [x] Go compiles
- [ ] `test-upgrade-preserves-config.sh` — install on port 9443, upgrade without flags, verify port preserved
- [ ] `test-upgrade-sqlite.sh` — now exercises config preservation (removed explicit `--quayHostname` from upgrade step)
- [ ] CI: new `test-upgrade-preserves-config` job in extended-tests.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)