### PR TITLE
fix(ci): fix SSL cert rotation health check and add missing --quayHostname

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -328,8 +328,7 @@ jobs:
             -addext "subjectAltName=DNS:quay"'
           ssh ci-user@control './mirror-registry upgrade -u ci-user -r /home/ci-user/quay-install -H quay \
             --sslCert /tmp/new-ssl.cert --sslKey /tmp/new-ssl.key -v -k ~/.ssh/id_rsa'
-          ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | grep -q HEALTHY || \
-            curl -sk https://localhost:8443/health/instance | grep -q HEALTHY'
+          ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | grep -q "\"status_code\":200"'
 
       - name: Uninstall Registry
         run: ssh ci-user@control './mirror-registry uninstall -u ci-user -H quay --autoApprove -v -k ~/.ssh/id_rsa'
@@ -507,9 +506,8 @@ jobs:
           ssh ci-user@quay 'openssl req -x509 -newkey rsa:2048 -keyout /tmp/new-ssl.key \
             -out /tmp/new-ssl.cert -days 365 -nodes -subj "/CN=quay" \
             -addext "subjectAltName=DNS:quay"'
-          ssh ci-user@quay './mirror-registry upgrade --sslCert /tmp/new-ssl.cert --sslKey /tmp/new-ssl.key -v'
-          ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | grep -q HEALTHY || \
-            curl -sk https://localhost:8443/health/instance | grep -q HEALTHY'
+          ssh ci-user@quay './mirror-registry upgrade --sslCert /tmp/new-ssl.cert --sslKey /tmp/new-ssl.key --quayHostname quay:8443 -v'
+          ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | grep -q "\"status_code\":200"'
 
       - name: Uninstall Quay
         run: ssh ci-user@quay './mirror-registry uninstall --autoApprove -v'


### PR DESCRIPTION
## Summary

- Replace `grep -q HEALTHY` with `grep -q '"status_code":200'` in SSL cert rotation health checks — the Quay health endpoint never returns the string "HEALTHY"
- Add `--quayHostname quay:8443` to the local install cert rotation upgrade command — without it, `loadCerts()` validates the cert SAN against the machine FQDN instead of `quay`

## Problem

Both SSL cert rotation CI tests (local + remote) added in PR #276 fail because `curl ... | grep -q HEALTHY` never matches — the response is `{"data":{"services":{...}},"status_code":200}`. The local test also fails at `loadCerts()` because the cert has `SAN=DNS:quay` but the upgrade defaults to the machine FQDN.

Verified locally: cert rotation upgrade works correctly, all services healthy, new cert is served. Only the CI test assertions were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)