### PR TITLE
fix: conditionally omit quay_hostname from extra vars to preserve existing config during upgrade (PROJQUAY-11690)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade-config-vars.yaml
@@ -30,13 +30,18 @@
     quay_config_file['DB_URI'] is string and
     (quay_config_file['DB_URI'] | urlsplit('scheme')) == 'postgresql'
 
-- name: Use existing SERVER_HOSTNAME if --quayHostname was not explicitly set
+- name: Use existing SERVER_HOSTNAME from config.yaml when --quayHostname was not passed
   ansible.builtin.set_fact:
     quay_hostname: "{{ quay_config_file['SERVER_HOSTNAME'] }}"
   when: >
-    quay_hostname_explicit | default('true') | lower != 'true' and
+    quay_hostname is not defined and
     'SERVER_HOSTNAME' in quay_config_file and
     quay_config_file['SERVER_HOSTNAME'] is string
+
+- name: Fall back to default quay_hostname if not set by CLI or config.yaml
+  ansible.builtin.set_fact:
+    quay_hostname: "{{ quay_hostname_default }}"
+  when: quay_hostname is not defined
 
 - name: Read existing quay-app.service for storage paths
   ansible.builtin.slurp:
@@ -44,16 +49,16 @@
   register: existing_quay_service_file
   ignore_errors: yes
 
-- name: Use existing quay_storage if --quayStorage was not explicitly set
+- name: Resolve quay_storage from existing service file if not explicitly set
   ansible.builtin.set_fact:
-    quay_storage: "{{ (existing_quay_service_file.content | b64decode) | regex_search('-v\\s+(\\S+):/datastorage', '\\1') | default([quay_storage], true) | first }}"
+    resolved_quay_storage: "{{ (existing_quay_service_file.content | b64decode) | regex_search('-v\\s+(\\S+):/datastorage', '\\1') | default([quay_storage], true) | first }}"
   when: >
     quay_storage_explicit | default('true') | lower != 'true' and
     existing_quay_service_file is succeeded
 
-- name: Use existing sqlite_storage if --sqliteStorage was not explicitly set
+- name: Resolve sqlite_storage from existing service file if not explicitly set
   ansible.builtin.set_fact:
-    sqlite_storage: "{{ (existing_quay_service_file.content | b64decode) | regex_search('-v\\s+(\\S+):/sqlite', '\\1') | default([sqlite_storage], true) | first }}"
+    resolved_sqlite_storage: "{{ (existing_quay_service_file.content | b64decode) | regex_search('-v\\s+(\\S+):/sqlite', '\\1') | default([sqlite_storage], true) | first }}"
   when: >
     sqlite_storage_explicit | default('true') | lower != 'true' and
     existing_quay_service_file is succeeded

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
@@ -16,6 +16,16 @@
 - name: Re-expand variables after config overrides
   include_tasks: expand-vars.yaml
 
+- name: Override expanded quay_storage with resolved value from existing install
+  ansible.builtin.set_fact:
+    expanded_quay_storage: "{{ resolved_quay_storage }}"
+  when: resolved_quay_storage is defined
+
+- name: Override expanded sqlite_storage with resolved value from existing install
+  ansible.builtin.set_fact:
+    expanded_sqlite_storage: "{{ resolved_sqlite_storage }}"
+  when: resolved_sqlite_storage is defined
+
 - name: Validate SSL Certificates
   include_tasks: validate-ssl-certs.yaml
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -189,6 +189,18 @@ func upgrade(cobraCmd *cobra.Command) {
 		sslCertKeyFlag = fmt.Sprintf(" -v %s:/runner/certs/quay.cert:Z -v %s:/runner/certs/quay.key:Z", sslCertAbs, sslKeyAbs)
 	}
 
+	// When quayHostname was explicitly passed, include it as quay_hostname in
+	// Ansible extra vars (highest precedence, overrides everything). When not
+	// explicit, omit quay_hostname from extra vars entirely so Ansible can
+	// read the existing SERVER_HOSTNAME from config.yaml via set_fact. Pass
+	// quay_hostname_default as a fallback for fresh installs with no config.
+	var quayHostnameExtraVar string
+	if quayHostnameExplicit {
+		quayHostnameExtraVar = fmt.Sprintf("quay_hostname=%s ", quayHostname)
+	} else {
+		quayHostnameExtraVar = fmt.Sprintf("quay_hostname_default=%s ", quayHostname)
+	}
+
 	// Run playbook
 	log.Printf("Running upgrade playbook. This may take some time. To see playbook output run the installer with -v (verbose) flag.")
 	quayVersion := strings.Split(quayImage, ":")[1]
@@ -208,8 +220,8 @@ func upgrade(cobraCmd *cobra.Command) {
 		`--quiet `+
 		`--name ansible_runner_instance `+
 		fmt.Sprintf("%s ", eeImage)+
-		`ansible-playbook -i %s@%s, --private-key /runner/env/ssh_key -e "quay_image=%s quay_version=%s redis_image=%s sqlite_image=%s pause_image=%s quay_hostname=%s quay_hostname_explicit=%s local_install=%s quay_root=%s quay_storage=%s quay_storage_explicit=%s sqlite_storage=%s sqlite_storage_explicit=%s" upgrade_mirror_appliance.yml %s %s`,
-		sshKey, targetUsername, targetHostname, quayImage, quayVersion, redisImage, sqliteImage, pauseImage, quayHostname, strconv.FormatBool(quayHostnameExplicit), strconv.FormatBool(isLocalInstall()), quayRoot, quayStorage, strconv.FormatBool(quayStorageExplicit), sqliteStorage, strconv.FormatBool(sqliteStorageExplicit), askBecomePassFlag, additionalArgs)
+		`ansible-playbook -i %s@%s, --private-key /runner/env/ssh_key -e "quay_image=%s quay_version=%s redis_image=%s sqlite_image=%s pause_image=%s %slocal_install=%s quay_root=%s quay_storage=%s quay_storage_explicit=%s sqlite_storage=%s sqlite_storage_explicit=%s" upgrade_mirror_appliance.yml %s %s`,
+		sshKey, targetUsername, targetHostname, quayImage, quayVersion, redisImage, sqliteImage, pauseImage, quayHostnameExtraVar, strconv.FormatBool(isLocalInstall()), quayRoot, quayStorage, strconv.FormatBool(quayStorageExplicit), sqliteStorage, strconv.FormatBool(sqliteStorageExplicit), askBecomePassFlag, additionalArgs)
 
 	log.Debug("Running command: " + podmanCmd)
 	cmd := exec.Command("bash", "-c", podmanCmd)

--- a/test/e2e/test-upgrade-preserves-config.sh
+++ b/test/e2e/test-upgrade-preserves-config.sh
@@ -14,15 +14,17 @@ log_info "=== Test: Upgrade Preserves Existing Config ==="
 
 # Install with custom port
 log_info "Installing with custom port ${CUSTOM_PORT}..."
-${MIRROR_REGISTRY} install -v \
+"${MIRROR_REGISTRY}" install -v \
     --quayHostname "${QUAY_ENDPOINT}" \
     --initPassword password
 
 wait_for_quay "${QUAY_ENDPOINT}"
 
 # Record pre-upgrade state
-pre_hostname=$(grep SERVER_HOSTNAME ~/quay-install/quay-config/config.yaml | awk '{print $2}')
+pre_hostname=$(grep '^SERVER_HOSTNAME' ~/quay-install/quay-config/config.yaml | awk '{print $2}')
+pre_storage=$(systemctl --user cat quay-app.service 2>/dev/null | grep -oP '\S+(?=:/datastorage)' | head -1)
 log_info "Pre-upgrade SERVER_HOSTNAME: ${pre_hostname}"
+log_info "Pre-upgrade datastorage mount: ${pre_storage}"
 
 # Push test image
 podman login -u init -p password "${QUAY_ENDPOINT}" --tls-verify=false
@@ -30,11 +32,10 @@ podman pull docker.io/library/busybox 2>/dev/null || true
 podman tag docker.io/library/busybox "${QUAY_ENDPOINT}/init/config-test:v1"
 podman push "${QUAY_ENDPOINT}/init/config-test:v1" --tls-verify=false
 
-# Upgrade WITHOUT passing --quayHostname (the bug scenario)
+# --- Test 1: Upgrade without flags preserves hostname ---
 log_info "Upgrading without --quayHostname flag..."
-${MIRROR_REGISTRY} upgrade -v
+"${MIRROR_REGISTRY}" upgrade -v
 
-# Verify port preserved
 wait_for_quay "${QUAY_ENDPOINT}"
 assert_quay_healthy "${QUAY_ENDPOINT}"
 
@@ -47,7 +48,7 @@ else
 fi
 
 # Verify SERVER_HOSTNAME preserved in config.yaml
-post_hostname=$(grep SERVER_HOSTNAME ~/quay-install/quay-config/config.yaml | awk '{print $2}')
+post_hostname=$(grep '^SERVER_HOSTNAME' ~/quay-install/quay-config/config.yaml | awk '{print $2}')
 if [[ "${pre_hostname}" == "${post_hostname}" ]]; then
     log_info "PASS: SERVER_HOSTNAME preserved (${post_hostname})"
     (( ++PASS_COUNT ))
@@ -61,7 +62,31 @@ podman rmi "${QUAY_ENDPOINT}/init/config-test:v1" 2>/dev/null || true
 assert_success "Pull image after upgrade" \
     podman pull "${QUAY_ENDPOINT}/init/config-test:v1" --tls-verify=false
 
+# Verify storage source path preserved in quay-app.service
+post_storage=$(systemctl --user cat quay-app.service 2>/dev/null | grep -oP '\S+(?=:/datastorage)' | head -1)
+if [[ -n "${pre_storage}" && "${pre_storage}" == "${post_storage}" ]]; then
+    log_info "PASS: quay-storage mount preserved (${post_storage})"
+    (( ++PASS_COUNT ))
+else
+    log_error "FAIL: quay-storage mount changed from ${pre_storage} to ${post_storage}"
+    (( ++FAIL_COUNT ))
+fi
+
+# --- Test 2: Explicit --quayHostname override still works ---
+log_info "Upgrading with explicit --quayHostname ${HOSTNAME}:7443..."
+"${MIRROR_REGISTRY}" upgrade --quayHostname "${HOSTNAME}:7443" -v
+
+wait_for_quay "${HOSTNAME}:7443"
+
+if ss -tlnp 2>/dev/null | grep -q ":7443 "; then
+    log_info "PASS: Explicit --quayHostname override to port 7443 works"
+    (( ++PASS_COUNT ))
+else
+    log_error "FAIL: Port 7443 not listening after explicit override"
+    (( ++FAIL_COUNT ))
+fi
+
 # Cleanup
-${MIRROR_REGISTRY} uninstall --autoApprove -v
+"${MIRROR_REGISTRY}" uninstall --autoApprove -v
 
 print_summary


### PR DESCRIPTION
## Summary

When upgrading without re-passing `--quayHostname`, the CLI defaulted to `<FQDN>:8443` and passed it as an Ansible extra var. Since extra vars have the highest precedence in Ansible, the existing `SERVER_HOSTNAME` from config.yaml could not override it — the pod was silently recreated on port 8443.

**Fix:** Conditionally omit `quay_hostname` from the Ansible extra vars when the user didn't pass `--quayHostname`. Ansible reads the existing value from config.yaml via `set_fact`, which now takes effect because there's no extra var to override it. A `quay_hostname_default` fallback is passed for edge cases where no config exists.

Storage paths (`quay_storage`, `sqlite_storage`) use a different approach since they're needed by `expand-vars.yaml` before config resolution: resolved values from the existing `quay-app.service` are written to `expanded_*` via a second `set_fact` (last-write-wins at same precedence).

Supersedes #287 which had the right idea but was defeated by Ansible variable precedence.

## Changes

| File | Change |
|------|--------|
| `cmd/upgrade.go` | When `--quayHostname` not explicit, pass `quay_hostname_default` instead of `quay_hostname` via `-e` |
| `upgrade-config-vars.yaml` | Set `quay_hostname` from `SERVER_HOSTNAME` when undefined; resolve storage paths into `resolved_*` vars |
| `upgrade.yaml` | Split storage `set_fact` into independent tasks (one per variable) |
| `upgrade-pod-service.yaml` | Remove stale `vars:` override |
| `test-upgrade-preserves-config.sh` | Add storage mount check, explicit override test (6 assertions total) |

## Test plan

- [x] Locally verified: install on port 9443, upgrade without flags → port 9443 preserved
- [x] Locally verified: explicit `--quayHostname quay:7443` override → port changes to 7443
- [x] Locally verified: storage volume mount preserved after upgrade
- [x] `test-upgrade-preserves-config.sh` passes: 6 passed, 0 failed
- [ ] CI: all 4 install types (local/remote, online/offline)
- [ ] CI: postgres-to-sqlite migration
- [ ] CI: SSL cert rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)