### PR TITLE
fix(ci): increase test job timeout from 60 to 90 minutes

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -191,7 +191,7 @@ jobs:
     needs: ["build-install-zip", "pull-images"]
     runs-on: ubuntu-latest
     environment: ci-testing
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test') # Skip on release
     strategy:
       fail-fast: false
@@ -392,7 +392,7 @@ jobs:
     needs: ["build-install-zip", "pull-images"]
     runs-on: ubuntu-latest
     environment: ci-testing
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: github.repository_owner == 'quay' && contains(github.event.pull_request.labels.*.name, 'ok-to-test') # Skip on release
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Increases `timeout-minutes` from 60 to 90 for both `test-remote-install` and `test-local-install` jobs
- The offline variants of these jobs regularly approach or exceed the 60-minute limit due to variable network latency in the Mirror Images step (`oc adm release mirror`)

**Evidence from recent runs:**

| Job | Run 1 | Run 2 | Run 3 |
|-----|------:|------:|------:|
| Remote Install (offline) | 62.1 min (CANCELLED) | 55.0 min | 61.8 min (CANCELLED) |
| Local Install (offline) | 51.4 min | 53.7 min | 59.9 min |
| Remote Install (online) | 45.6 min | 42.4 min | 46.7 min |
| Local Install (online) | 37.5 min | 41.8 min | 49.1 min |

The online variants are unaffected by this change since they complete well within 60 minutes.

## Test plan

- [ ] Verify Remote Install (offline) completes without timeout cancellation
- [ ] Verify Local Install (offline) has sufficient headroom

🤖 Generated with [Claude Code](https://claude.com/claude-code)