### PR TITLE
chore: bump Quay image from v3.12.16 to v3.12.18

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 EE_IMAGE=quay.io/quay/mirror-registry-ee:latest
 EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:2.0
 EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-25/ansible-builder-rhel8:3.1.1
-QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.12.16
+QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.12.18
 REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-1766406130
 PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:8.10-5
 SQLITE_IMAGE=quay.io/projectquay/sqlite-cli:latest


### PR DESCRIPTION
## Summary
- Bumps `QUAY_IMAGE` in `.env` from `v3.12.16` to `v3.12.18`

## Test plan
- [ ] CI integration tests pass with the new image version

🤖 Generated with [Claude Code](https://claude.com/claude-code)