### PR TITLE
fix: preserve existing quayRoot during upgrade (PROJQUAY-11690)

### DIFF
--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/upgrade.yaml
@@ -1,3 +1,21 @@
+- name: Discover quay_root from existing install if not explicitly set
+  block:
+    - name: Read existing quay-app.service to discover quay_root
+      ansible.builtin.slurp:
+        src: "{{ systemd_unit_dir }}/quay-app.service"
+      register: existing_service_for_root
+
+    - name: Extract quay_root from service file volume mount
+      ansible.builtin.set_fact:
+        quay_root: "{{ (existing_service_for_root.content | b64decode) | regex_search('-v\\s+(\\S+)/quay-config:/quay-registry/conf/stack', '\\1') | first }}"
+  when: quay_root is not defined
+  ignore_errors: yes
+
+- name: Fall back to default quay_root if not discovered
+  ansible.builtin.set_fact:
+    quay_root: "{{ quay_root_default | default('~/quay-install') }}"
+  when: quay_root is not defined
+
 - name: Expand variables
   include_tasks: expand-vars.yaml
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -59,6 +59,7 @@ func upgrade(cobraCmd *cobra.Command) {
 
 	// Detect which flags the user explicitly passed
 	quayHostnameExplicit := cobraCmd.Flags().Changed("quayHostname")
+	quayRootExplicit := cobraCmd.Flags().Changed("quayRoot")
 	quayStorageExplicit := cobraCmd.Flags().Changed("quayStorage")
 	sqliteStorageExplicit := cobraCmd.Flags().Changed("sqliteStorage")
 
@@ -189,16 +190,22 @@ func upgrade(cobraCmd *cobra.Command) {
 		sslCertKeyFlag = fmt.Sprintf(" -v %s:/runner/certs/quay.cert:Z -v %s:/runner/certs/quay.key:Z", sslCertAbs, sslKeyAbs)
 	}
 
-	// When quayHostname was explicitly passed, include it as quay_hostname in
-	// Ansible extra vars (highest precedence, overrides everything). When not
-	// explicit, omit quay_hostname from extra vars entirely so Ansible can
-	// read the existing SERVER_HOSTNAME from config.yaml via set_fact. Pass
-	// quay_hostname_default as a fallback for fresh installs with no config.
+	// When a flag was explicitly passed, include it in Ansible extra vars
+	// (highest precedence). When not explicit, omit it so Ansible can read
+	// the existing value from the target host via set_fact. Pass a _default
+	// fallback for edge cases where no existing install is found.
 	var quayHostnameExtraVar string
 	if quayHostnameExplicit {
 		quayHostnameExtraVar = fmt.Sprintf("quay_hostname=%s ", quayHostname)
 	} else {
 		quayHostnameExtraVar = fmt.Sprintf("quay_hostname_default=%s ", quayHostname)
+	}
+
+	var quayRootExtraVar string
+	if quayRootExplicit {
+		quayRootExtraVar = fmt.Sprintf("quay_root=%s ", quayRoot)
+	} else {
+		quayRootExtraVar = fmt.Sprintf("quay_root_default=%s ", quayRoot)
 	}
 
 	// Run playbook
@@ -220,8 +227,8 @@ func upgrade(cobraCmd *cobra.Command) {
 		`--quiet `+
 		`--name ansible_runner_instance `+
 		fmt.Sprintf("%s ", eeImage)+
-		`ansible-playbook -i %s@%s, --private-key /runner/env/ssh_key -e "quay_image=%s quay_version=%s redis_image=%s sqlite_image=%s pause_image=%s %slocal_install=%s quay_root=%s quay_storage=%s quay_storage_explicit=%s sqlite_storage=%s sqlite_storage_explicit=%s" upgrade_mirror_appliance.yml %s %s`,
-		sshKey, targetUsername, targetHostname, quayImage, quayVersion, redisImage, sqliteImage, pauseImage, quayHostnameExtraVar, strconv.FormatBool(isLocalInstall()), quayRoot, quayStorage, strconv.FormatBool(quayStorageExplicit), sqliteStorage, strconv.FormatBool(sqliteStorageExplicit), askBecomePassFlag, additionalArgs)
+		`ansible-playbook -i %s@%s, --private-key /runner/env/ssh_key -e "quay_image=%s quay_version=%s redis_image=%s sqlite_image=%s pause_image=%s %s%slocal_install=%s quay_storage=%s quay_storage_explicit=%s sqlite_storage=%s sqlite_storage_explicit=%s" upgrade_mirror_appliance.yml %s %s`,
+		sshKey, targetUsername, targetHostname, quayImage, quayVersion, redisImage, sqliteImage, pauseImage, quayHostnameExtraVar, quayRootExtraVar, strconv.FormatBool(isLocalInstall()), quayStorage, strconv.FormatBool(quayStorageExplicit), sqliteStorage, strconv.FormatBool(sqliteStorageExplicit), askBecomePassFlag, additionalArgs)
 
 	log.Debug("Running command: " + podmanCmd)
 	cmd := exec.Command("bash", "-c", podmanCmd)

--- a/test/e2e/test-upgrade-preserves-config.sh
+++ b/test/e2e/test-upgrade-preserves-config.sh
@@ -86,7 +86,47 @@ else
     (( ++FAIL_COUNT ))
 fi
 
-# Cleanup
+# Cleanup test 1+2
 "${MIRROR_REGISTRY}" uninstall --autoApprove -v
+
+# --- Test 3: Custom quayRoot preserved on upgrade ---
+CUSTOM_ROOT="/tmp/omr-test-root-$$"
+mkdir -p "${CUSTOM_ROOT}"
+log_info "Installing with custom quayRoot ${CUSTOM_ROOT}..."
+"${MIRROR_REGISTRY}" install -v \
+    --quayHostname "${HOSTNAME}:8443" \
+    --initPassword password \
+    --quayRoot "${CUSTOM_ROOT}"
+
+wait_for_quay "${HOSTNAME}:8443"
+
+# Verify config.yaml is at the custom path
+if [[ -f "${CUSTOM_ROOT}/quay-config/config.yaml" ]]; then
+    log_info "PASS: config.yaml exists at custom quayRoot"
+    (( ++PASS_COUNT ))
+else
+    log_error "FAIL: config.yaml not found at ${CUSTOM_ROOT}/quay-config/config.yaml"
+    (( ++FAIL_COUNT ))
+fi
+
+# Upgrade without --quayRoot
+log_info "Upgrading without --quayRoot flag..."
+"${MIRROR_REGISTRY}" upgrade -v
+
+wait_for_quay "${HOSTNAME}:8443"
+assert_quay_healthy "${HOSTNAME}:8443"
+
+# Verify config.yaml still at custom path (not default ~/quay-install)
+if [[ -f "${CUSTOM_ROOT}/quay-config/config.yaml" ]]; then
+    log_info "PASS: Custom quayRoot preserved after upgrade (${CUSTOM_ROOT})"
+    (( ++PASS_COUNT ))
+else
+    log_error "FAIL: Custom quayRoot lost — config.yaml not at ${CUSTOM_ROOT}"
+    (( ++FAIL_COUNT ))
+fi
+
+# Cleanup test 3
+"${MIRROR_REGISTRY}" uninstall --autoApprove -v --quayRoot "${CUSTOM_ROOT}"
+rm -rf "${CUSTOM_ROOT}"
 
 print_summary


### PR DESCRIPTION
## Summary

When upgrading without re-passing `--quayRoot`, the CLI defaults to `~/quay-install` and passes it via Ansible extra vars. If the customer installed with a custom `--quayRoot` (e.g. `/home/user/testdata/quay_root`), the upgrade fails with `file not found: ~/quay-install/quay-config/config.yaml` because it looks in the wrong directory.

**Fix:** Same pattern as #292 for `--quayHostname` — conditionally omit `quay_root` from `-e` when not explicit. Ansible discovers the actual `quay_root` from the existing `quay-app.service` volume mount before `expand-vars.yaml` runs.

## Changes

| File | Change |
|------|--------|
| `cmd/upgrade.go` | Add `quayRootExplicit`, conditionally pass `quay_root` or `quay_root_default` |
| `upgrade.yaml` | Add discovery block at top: read service file, extract quay_root, fallback to default |
| `test-upgrade-preserves-config.sh` | Add Test 3: install with custom quayRoot, upgrade without flag, verify preserved |

## Test plan

- [x] Install with `--quayRoot /home/ec2-user/testdata/quay_root`, upgrade without flag → upgrade succeeds, config found at custom path
- [x] `test-upgrade-preserves-config.sh`: 9 passed, 0 failed (hostname + storage + quayRoot)
- [ ] CI: all 4 install types

🤖 Generated with [Claude Code](https://claude.com/claude-code)