### PR TITLE
fix: hard-fail on partial --sslCert/--sslKey input during upgrade (PROJQUAY-7979)

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -330,6 +330,14 @@ jobs:
             --sslCert /tmp/new-ssl.cert --sslKey /tmp/new-ssl.key -v -k ~/.ssh/id_rsa'
           ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | grep -q "\"status_code\":200"'
 
+      - name: Test remote upgrade fails when only --sslCert is provided
+        run: |
+          if ssh ci-user@control './mirror-registry upgrade -u ci-user -r /home/ci-user/quay-install -H quay --sslCert /tmp/new-ssl.cert -v -k ~/.ssh/id_rsa' 2>&1; then
+            echo "FAIL: upgrade should have failed with only --sslCert"
+            exit 1
+          fi
+          echo "PASS: upgrade correctly rejected partial SSL flag input"
+
       - name: Uninstall Registry
         run: ssh ci-user@control './mirror-registry uninstall -u ci-user -H quay --autoApprove -v -k ~/.ssh/id_rsa'
 
@@ -508,6 +516,14 @@ jobs:
             -addext "subjectAltName=DNS:quay"'
           ssh ci-user@quay './mirror-registry upgrade --sslCert /tmp/new-ssl.cert --sslKey /tmp/new-ssl.key --quayHostname quay:8443 -v'
           ssh ci-user@quay 'curl -sk https://quay:8443/health/instance | grep -q "\"status_code\":200"'
+
+      - name: Test upgrade fails when only --sslCert is provided
+        run: |
+          if ssh ci-user@quay './mirror-registry upgrade --sslCert /tmp/new-ssl.cert -v' 2>&1; then
+            echo "FAIL: upgrade should have failed with only --sslCert"
+            exit 1
+          fi
+          echo "PASS: upgrade correctly rejected partial SSL flag input"
 
       - name: Uninstall Quay
         run: ssh ci-user@quay './mirror-registry uninstall --autoApprove -v'

--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -332,8 +332,13 @@ jobs:
 
       - name: Test remote upgrade fails when only --sslCert is provided
         run: |
-          if ssh ci-user@control './mirror-registry upgrade -u ci-user -r /home/ci-user/quay-install -H quay --sslCert /tmp/new-ssl.cert -v -k ~/.ssh/id_rsa' 2>&1; then
+          output=$(ssh ci-user@control './mirror-registry upgrade -u ci-user -r /home/ci-user/quay-install -H quay --sslCert /tmp/new-ssl.cert -v -k ~/.ssh/id_rsa' 2>&1) && {
             echo "FAIL: upgrade should have failed with only --sslCert"
+            exit 1
+          }
+          if ! grep -Fq "Both --sslCert and --sslKey must be provided together" <<<"$output"; then
+            echo "FAIL: upgrade failed, but not for partial SSL flag validation"
+            echo "$output"
             exit 1
           fi
           echo "PASS: upgrade correctly rejected partial SSL flag input"
@@ -519,8 +524,13 @@ jobs:
 
       - name: Test upgrade fails when only --sslCert is provided
         run: |
-          if ssh ci-user@quay './mirror-registry upgrade --sslCert /tmp/new-ssl.cert -v' 2>&1; then
+          output=$(ssh ci-user@quay './mirror-registry upgrade --sslCert /tmp/new-ssl.cert -v' 2>&1) && {
             echo "FAIL: upgrade should have failed with only --sslCert"
+            exit 1
+          }
+          if ! grep -Fq "Both --sslCert and --sslKey must be provided together" <<<"$output"; then
+            echo "FAIL: upgrade failed, but not for partial SSL flag validation"
+            echo "$output"
             exit 1
           fi
           echo "PASS: upgrade correctly rejected partial SSL flag input"

--- a/ansible-runner/context/app/project/roles/mirror_appliance/tasks/validate-ssl-certs.yaml
+++ b/ansible-runner/context/app/project/roles/mirror_appliance/tasks/validate-ssl-certs.yaml
@@ -10,15 +10,6 @@
   delegate_to: localhost
   register: new_ssl_key
 
-- name: Fail if only one SSL file is provided
-  fail:
-    msg: >-
-      Both --sslCert and --sslKey must be provided together.
-      Re-run upgrade with both flags.
-  when: >
-    (new_ssl_cert.stat.exists and not new_ssl_key.stat.exists) or
-    (new_ssl_key.stat.exists and not new_ssl_cert.stat.exists)
-
 - name: Copy new SSL certificates to target host
   block:
     - name: Copy new SSL certificate

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -80,7 +80,7 @@ func upgrade(cobraCmd *cobra.Command) {
 	check(err)
 
 	if (sslCert != "" && sslKey == "") || (sslCert == "" && sslKey != "") {
-		log.Warn("Both --sslCert and --sslKey must be provided together. Only one was specified, so no certificate will be used.")
+		check(errors.New("Both --sslCert and --sslKey must be provided together. Only one was specified."))
 	}
 
 	// Check that SSH key is present, and generate if not


### PR DESCRIPTION
## Summary

Fix partial `--sslCert`/`--sslKey` flag input handling during upgrade. When only one flag is provided, the upgrade now fails immediately with a clear error instead of continuing with misleading warnings.

## Problem

When a user runs `./mirror-registry upgrade --sslCert /tmp/cert.pem -v` (without `--sslKey`):

1. Go logged a non-fatal warning but continued running the full Ansible playbook
2. Since Go requires both flags to mount certs into the Ansible EE container, nothing was mounted
3. Ansible saw no certs in `/runner/certs/`, skipped the copy, then checked the target host
4. Ansible warned about BOTH `ssl.cert` AND `ssl.key` missing — even though the user provided a cert
5. The user saw three confusing messages instead of one clear error

Additionally, `validate-ssl-certs.yaml` had a "Fail if only one SSL file is provided" task that could never trigger, because Go only mounts files when both flags are present — so Ansible would never see just one file in `/runner/certs/`.

## Fix

**`cmd/upgrade.go`**: Changed the partial-input warning to a hard error (`check(errors.New(...))` instead of `log.Warn`). The upgrade stops at the Go level before any Ansible playbook runs, SSH connections, or service changes.

**`validate-ssl-certs.yaml`**: Removed the dead partial-input fail-fast task (lines 13-20) since it was unreachable.

**`jobs.yml`**: Added CI tests for the partial flag scenario in both local and remote install jobs.

## User flow after fix

```bash
$ ./mirror-registry upgrade --sslCert /tmp/cert.pem -v
...
ERRO An error occurred: Both --sslCert and --sslKey must be provided together. Only one was specified.
$ echo $?
1
```

## Note on `--sslCheckSkip`

A separate report suggested `--sslCheckSkip` should suppress Ansible cert warnings. After investigation, this is working as designed — `--sslCheckSkip` was introduced in PR #17 (2021) to skip Go-side X.509 hostname validation in `loadCerts()`, not to skip cert existence checks. The Ansible warnings about missing certs are correct behavior regardless of this flag.

## Test plan

- [x] `--sslCert` only → hard error, exit 1 (verified locally)
- [x] `--sslKey` only → hard error, exit 1 (verified locally)
- [x] Both `--sslCert` and `--sslKey` → works as before (verified locally)
- [x] No flags, certs exist → upgrade works (verified locally)
- [x] No flags, certs missing → warning shown (verified locally)
- [x] `--sslCheckSkip` → skips Go hostname validation only (verified locally)
- [ ] CI: local + remote partial flag tests

All tests run against a real OMR install on RHEL.