### PR TITLE
PROJQUAY-11621: docs: add repo context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,16 @@ Read the specific documentation below when your task involves these keywords:
 - **Ansible**: Follow existing role structure in `mirror_appliance`
 - **Testing**: PRs require `ok-to-test` label for CI integration tests
 - **Safety**: Never commit credentials or secrets
+
+## Contextification Addendum
+
+Low-token routing:
+
+- CLI commands: `cmd/*.go`
+- Embedded installer: `ansible-runner/context/`
+- E2E tests: `test/e2e/`
+- Build/package targets: `Makefile`
+
+Commands: `make build-golang-executable`, `make build-online-zip`, `make build-offline-zip`.
+
+Guardrail: installer validation should use a clean host or VM because it creates systemd units, storage, and persistent config.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,173 @@
+# mirror-registry Architecture
+
+## Purpose
+
+CLI for installing Quay on RHEL/Fedora for air-gapped OpenShift environments.
+
+```mermaid
+flowchart TB
+    cli[mirror-registry CLI]
+    preflight[host preflight checks]
+    ansible[embedded Ansible runner]
+    systemd[systemd units]
+    services[Quay, PostgreSQL, Redis]
+    user[local or disconnected user]
+
+    user --> cli
+    cli --> preflight
+    preflight --> ansible
+    ansible --> systemd
+    systemd --> services
+```
+
+## High-Level Design
+
+```
+mirror-registry CLI
+    ↓ Ansible playbooks
+Podman + systemd services
+    ↓ Container runtime
+[Postgres, Redis, Quay]
+```
+
+## Components
+
+### `/cmd/mirror-registry`
+CLI entrypoint:
+- `install`: Initial deployment
+- `upgrade`: Version upgrade
+- `uninstall`: Full removal
+- `pause`/`unpause`: Service control
+
+### `/ansible-runner`
+Embedded Ansible playbooks:
+- `install.yml`: Fresh install
+- `upgrade.yml`: Version migration
+- `uninstall.yml`: Cleanup
+- Roles: postgres, redis, quay, certificates
+
+### `/pkg/installer`
+Install orchestration:
+- Preflight checks (ports, disk, selinux)
+- Ansible execution
+- Systemd service creation
+
+## Install Flow
+
+```
+1. CLI: mirror-registry install --quayHostname quay.example.com
+2. Preflight checks:
+   - RHEL/Fedora version
+   - Podman installed
+   - Ports 80/443/5432/6379 available
+   - Disk space (>50GB)
+   - SELinux mode
+3. Generate certificates (self-signed or provided)
+4. Run Ansible:
+   a. Install Postgres container (systemd unit)
+   b. Initialize Quay database
+   c. Install Redis container (systemd unit)
+   d. Generate Quay config.yaml
+   e. Install Quay container (systemd unit)
+5. Start services via systemd
+6. Print login credentials
+```
+
+## Ansible Roles
+
+### `postgres` role
+```yaml
+- Pull postgres:13 image
+- Create /var/lib/pgsql-mirror-registry volume
+- Generate systemd unit (postgresql-mirror-registry.service)
+- Enable + start service
+- Create quay database
+```
+
+### `redis` role
+```yaml
+- Pull redis:6 image
+- Generate systemd unit (redis-mirror-registry.service)
+- Enable + start service
+```
+
+### `quay` role
+```yaml
+- Pull quay:<version> image
+- Generate config.yaml (postgres + redis endpoints)
+- Create /var/lib/quay-mirror-registry volume
+- Generate systemd unit (quay-mirror-registry.service)
+- Enable + start service
+```
+
+## Configuration
+
+Generated in `/etc/quay-mirror-registry/config.yaml`:
+
+```yaml
+DB_URI: postgresql://postgres@localhost/quay
+BUILDLOGS_REDIS:
+  host: localhost
+  port: 6379
+USER_EVENTS_REDIS:
+  host: localhost
+  port: 6379
+FEATURE_MAILING: false
+PREFERRED_URL_SCHEME: https
+SERVER_HOSTNAME: quay.example.com
+```
+
+## Systemd Services
+
+```
+postgresql-mirror-registry.service
+redis-mirror-registry.service
+quay-mirror-registry.service
+```
+
+All use:
+- Restart=always
+- Podman container backend
+- Host network mode
+
+## Upgrade Flow
+
+```
+1. CLI: mirror-registry upgrade --targetVersion 3.11.0
+2. Pull new Quay image
+3. Stop quay-mirror-registry.service
+4. Run database migrations (if needed)
+5. Update systemd unit with new image
+6. Start quay-mirror-registry.service
+7. Verify health
+```
+
+## Uninstall Flow
+
+```
+1. CLI: mirror-registry uninstall
+2. Stop all services
+3. Remove containers
+4. Remove systemd units
+5. Optionally remove data directories
+```
+
+## Offline/Air-Gapped Support
+
+```
+1. Download bundle on connected host:
+   mirror-registry package --targetVersion 3.11.0
+
+2. Transfer bundle to air-gapped host
+
+3. Install from bundle:
+   mirror-registry install --from-bundle mirror-registry.tar.gz
+```
+
+## File Locations
+
+- Binaries: `/usr/local/bin/mirror-registry`
+- Config: `/etc/quay-mirror-registry/`
+- Data: `/var/lib/quay-mirror-registry/`, `/var/lib/pgsql-mirror-registry/`
+- Systemd: `/etc/systemd/system/*-mirror-registry.service`
+- Certificates: `/etc/quay-mirror-registry/ssl/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to mirror-registry
+
+## Setup
+
+```bash
+# Requires Go 1.21+ and Ansible
+make build
+
+# Test install locally
+./mirror-registry install --quayHostname localhost
+```
+
+## Development
+
+CLI for air-gapped Quay deployments on RHEL/Fedora.
+
+Wraps:
+- Podman/systemd for container runtime
+- Ansible playbooks for config management
+- Postgres/Redis via containers
+
+## Testing
+
+```bash
+# Unit tests
+make test
+
+# Integration test (requires VM)
+./test/integration.sh
+
+# Manual test on fresh RHEL
+vagrant up
+vagrant ssh
+./mirror-registry install
+```
+
+## Pull Requests
+
+- Test on RHEL 8, RHEL 9, Fedora
+- Update Ansible playbooks in `ansible-runner/`
+- Document new flags in README
+- Verify uninstall cleans up fully
+
+## Code Structure
+
+- `cmd/mirror-registry/` - CLI entrypoint
+- `ansible-runner/` - embedded Ansible playbooks
+- `test/` - integration tests
+- `pkg/` - install/upgrade logic

--- a/README.md
+++ b/README.md
@@ -170,3 +170,23 @@ tar -xzvf mirror-registry.tar.gz -C mirror-registry
 ```
 
 **NOTE** This command may take some time to complete depending on host resources. 
+
+## Contextification Addendum
+
+```mermaid
+flowchart TB
+    admin[Administrator]
+    cli[mirror-registry CLI]
+    ansible[embedded Ansible]
+    systemd[user systemd services]
+    services[Quay, Redis, storage]
+
+    admin --> cli
+    cli --> ansible
+    ansible --> systemd
+    systemd --> services
+```
+
+Key paths: `cmd/`, `ansible-runner/context/`, `test/e2e/`, and `Makefile`. Build with `make build-golang-executable`, `make build-online-zip`, and `make build-offline-zip`.
+
+Installer tests change host state; validate install, upgrade, and uninstall on a clean RHEL/Fedora host or VM.


### PR DESCRIPTION
## Summary
Adds required contextification docs for `mirror-registry` as part of [PROJQUAY-11621](https://redhat.atlassian.net/browse/PROJQUAY-11621).

## Changes
  - Adds `ARCHITECTURE.md` with install flow, components, systemd layout, and offline support context.
  - Adds `CONTRIBUTING.md` with setup, testing, and review guidance.
  - Updates `README.md` with a contextification addendum, architecture diagram, key paths, and validation notes.
  - Updates `AGENTS.md` with low-token routing for AI agents.