### PR TITLE
[mirror-registry-2.0-rhel-8] fix(proxy): prevent SSRF in proxy cache upstream registry configuration (PROJQUAY-10896)

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 EE_IMAGE=quay.io/quay/mirror-registry-ee:latest
 EE_BASE_IMAGE=registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:2.0
 EE_BUILDER_IMAGE=registry.redhat.io/ansible-automation-platform-25/ansible-builder-rhel8:3.1.1
-QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.12.18
+QUAY_IMAGE=registry.redhat.io/quay/quay-rhel8:v3.12.20
 REDIS_IMAGE=registry.redhat.io/rhel8/redis-6:1-1766406130
 PAUSE_IMAGE=registry.access.redhat.com/ubi8/pause:8.10-5
 SQLITE_IMAGE=quay.io/projectquay/sqlite-cli:latest


### PR DESCRIPTION
Quay image v3.12.18 -> v3.12.20 Bump (CVE-2026-32591)
1 file changed (same pattern as PR #296 / PR #302)


File                  Change
=================================================
.env                  ->QUAY_IMAGE: v3.12.18 -> v3.12.20

Resolves [PROJQUAY-10896](https://redhat.atlassian.net/browse/PROJQUAY-10896) for mirror-registry-2.0-rhel-8 branch