### PR TITLE
Migrate from deprecated oc-installer to openshift-tools-installer

### DIFF
--- a/.github/workflows/jobs.yml
+++ b/.github/workflows/jobs.yml
@@ -206,9 +206,9 @@ jobs:
           persist-credentials: false
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
+        uses: redhat-actions/openshift-tools-installer@ebd96c3fc72fc10a62663eac5e1421192152e6aa # v2
         with:
-          oc_version: "4.6"
+          oc: "4"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1
@@ -420,9 +420,9 @@ jobs:
           persist-credentials: false
 
       - name: Install oc
-        uses: redhat-actions/oc-installer@35b60c3f9757ae4301521556e1b75ff6f59f8d7c # v1
+        uses: redhat-actions/openshift-tools-installer@ebd96c3fc72fc10a62663eac5e1421192152e6aa # v2
         with:
-          oc_version: "4.6"
+          oc: "4"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@ed3a0531877aca392eb870f440d9ae7aba83a6bd # v1


### PR DESCRIPTION
## Summary

- Replace `redhat-actions/oc-installer` (pinned to SHA) with `redhat-actions/openshift-tools-installer@v2` in both jobs in the CI workflow
- Uses `oc: "4"` to match the previous `oc_version: "4.6"` while allowing newer 4.x patch releases

## Why

`redhat-actions/oc-installer` is deprecated:
- The download mirror it points to has not been updated since December 2020
- The action now emits a deprecation warning at runtime ([redhat-actions/oc-installer#32](https://github.com/redhat-actions/oc-installer/pull/32))

`openshift-tools-installer` is the actively maintained successor, supporting semver ranges, arm64, cross-workflow caching, and 18+ tools.

Closes #304

## Test plan

- [ ] Verify CI jobs install `oc` successfully with the new action